### PR TITLE
Fix Python syntax error in search.py

### DIFF
--- a/archai/data_aug/search.py
+++ b/archai/data_aug/search.py
@@ -340,7 +340,7 @@ def _eval_tta(conf, augment, reporter):
     loaders = []
     for _ in range(augment['num_policy']):
         tl, validloader, tl2 = get_dataloaders(augment['dataroot'], ds_name,
-            , aug, cutout,
+            aug, cutout,
             load_train=True, load_test=True,
             val_ratio=val_ratio, val_fold=val_fold, n_workers=n_workers)
         loaders.append(iter(validloader))


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/microsoft/archai on Python 3.9.0rc2+

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./archai/data_aug/search.py:343:13: E999 SyntaxError: invalid syntax
            , aug, cutout,
            ^
1     E999 SyntaxError: invalid syntax
1
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.