### PR TITLE
Sets ray's number of cpus using ps_utils.

### DIFF
--- a/archai/common/apex_utils.py
+++ b/archai/common/apex_utils.py
@@ -91,7 +91,9 @@ class ApexUtils:
             if not ray.is_initialized():
                 ray.init(local_mode=self.ray_local_mode, include_dashboard=False,
                          # for some reason Ray is detecting wrong number of GPUs
-                         num_gpus=torch.cuda.device_count())
+                         num_gpus=torch.cuda.device_count(),
+                         # number of CPUs as well
+                         num_cpus=psutil.cpu_count())
                 ray_cpus = ray.nodes()[0]['Resources']['CPU']
                 ray_gpus = ray.nodes()[0]['Resources']['GPU']
                 self._log_info({'ray_cpus': ray_cpus, 'ray_gpus':ray_gpus})


### PR DESCRIPTION
On some platforms ray won't detect the correct number of CPUs, psutil should be more stable.