### PR TITLE
fix(nvidia_transformer_xl): Workaround to allow for torch stack and unbind when using past_key_values.

### DIFF
--- a/archai/nlp/nvidia_transformer_xl/mem_transformer.py
+++ b/archai/nlp/nvidia_transformer_xl/mem_transformer.py
@@ -287,16 +287,19 @@ class RelPartialLearnableMultiHeadAttn(RelMultiHeadAttn):
         w_head_k = w_head_k.view(klen, bsz, self.n_head, self.d_head)  # klen x bsz x n_head x d_head
         w_head_v = w_head_v.view(klen, bsz, self.n_head, self.d_head)  # klen x bsz x n_head x d_head
 
-        r_head_k = r_head_k.view(rlen, bsz, self.n_head, self.d_head)  # qlen x bsz x n_head x d_head
+        r_head_k = r_head_k.view(rlen, self.n_head, self.d_head)  # qlen x n_head x d_head
 
         if past_key_values is not None:
             past_k, past_v, past_r = torch.unbind(past_key_values, dim=0)
+            past_r = past_r[:, 0, :, :]
             w_head_k = torch.cat((past_k, w_head_k), dim=0)
             w_head_v = torch.cat((past_v, w_head_v), dim=0)
             r_head_k = torch.cat((past_r, r_head_k), dim=0)
 
         if self.use_cache:
-            present_key_values = torch.stack([w_head_k, w_head_v, r_head_k], dim=0)
+            # Caveat that allows for torch `stack` and `unbind`
+            _r_head_k = r_head_k.unsqueeze(1).expand(-1, bsz, -1, -1)
+            present_key_values = torch.stack([w_head_k, w_head_v, _r_head_k], dim=0)
         else:
             present_key_values = None
 
@@ -305,7 +308,7 @@ class RelPartialLearnableMultiHeadAttn(RelMultiHeadAttn):
         AC = torch.einsum('ibnd,jbnd->bnij', (rw_head_q, w_head_k))    # bsz x n_head x qlen x klen
 
         rr_head_q = w_head_q + r_r_bias
-        BD = torch.einsum('ibnd,jbnd->bnij', (rr_head_q, r_head_k))     # bsz x n_head x qlen x klen
+        BD = torch.einsum('ibnd,jnd->bnij', (rr_head_q, r_head_k))     # bsz x n_head x qlen x klen
         BD = self._rel_shift(BD)
 
         # [bsz x n_head x qlen x klen]
@@ -797,7 +800,7 @@ class MemTransformerLM(nn.Module):
                                    dtype=word_emb.dtype)
             if self.clamp_len > 0:
                 pos_seq.clamp_(max=self.clamp_len)
-            pos_emb = self.pos_emb(pos_seq, bsz=bsz)
+            pos_emb = self.pos_emb(pos_seq)
 
             core_out = self.drop(word_emb)
             pos_emb = self.drop(pos_emb)
@@ -831,7 +834,7 @@ class MemTransformerLM(nn.Module):
                                    dtype=word_emb.dtype)
             if self.clamp_len > 0:
                 pos_seq.clamp_(max=self.clamp_len)
-            pos_emb = self.pos_emb(pos_seq, bsz=bsz)
+            pos_emb = self.pos_emb(pos_seq)
 
             core_out = self.drop(word_emb + pos_emb[-qlen:])
 


### PR DESCRIPTION
This PR serves as a workaround for allowing torch `stack` and `unbind` when calculating the `past_key_values`. Essentially, it is an alternate version that will not modify the training step.