### PR TITLE
Conv1d qat training

### DIFF
--- a/archai/nlp/nvidia_transformer_xl/mem_transformer.py
+++ b/archai/nlp/nvidia_transformer_xl/mem_transformer.py
@@ -700,7 +700,7 @@ class MemTransformerLM(nn.Module):
         self.sample_softmax = -1
 
     @staticmethod
-    def load_model(path:str, model:Optional['MemTransformerLM'], on_cpu:bool) -> Tuple['MemTransformerLM', dict, dict]:
+    def load_model(path:str, model:Optional['MemTransformerLM']=None, on_cpu:Optional[bool]=False) -> Tuple['MemTransformerLM', dict, dict]:
         # case for restart
         if os.path.isdir(path):
             path = os.path.join(path, 'checkpoint_last.pt')
@@ -715,6 +715,11 @@ class MemTransformerLM(nn.Module):
         checkpoint = torch.load(path, map_location=dst)
 
         model_config = checkpoint['model_config']
+
+        # Compatibility with older models
+        # TODO: remove once not needed
+        if 'encoder_like' in model_config:
+            del model_config['encoder_like']
 
         # Initializes the model
         model = MemTransformerLM(**model_config) if model is None else model

--- a/archai/nlp/nvidia_transformer_xl/nvidia_utils/exp_utils.py
+++ b/archai/nlp/nvidia_transformer_xl/nvidia_utils/exp_utils.py
@@ -250,7 +250,8 @@ def dataset_dir_name(dataset:str)->str:
 
 def get_create_dirs(dataroot:Optional[str], dataset_name:str,
                     experiment_name='nv_xformer_xl', output_dir='~/logdir',
-                    cache_dir:Optional[str]=None)->Tuple[str,str,str,str]:
+                    pretrained_path:Optional[str]=None, cache_dir:Optional[str]=None)->Tuple[str,str,str,str,str]:
+
     pt_data_dir, pt_output_dir = common.pt_dirs()
     dataroot = dataroot or pt_data_dir or common.default_dataroot()
     dataroot = utils.full_path(dataroot)
@@ -259,10 +260,16 @@ def get_create_dirs(dataroot:Optional[str], dataset_name:str,
     output_dir=  utils.full_path(pt_output_dir or \
                         os.path.join(output_dir, experiment_name)
                     , create=True)
-    cache_dir = cache_dir or os.path.join(dataset_dir, 'cache')
+
+    if not os.path.isabs(cache_dir):
+        cache_dir = os.path.join(dataset_dir, cache_dir)
+    
     cache_dir = utils.full_path(cache_dir, create=True)
 
-    return dataset_dir, output_dir, cache_dir, dataroot
+    if not os.path.isabs(pretrained_path):
+        pretrained_path = os.path.join(os.path.dirname(pt_output_dir), pretrained_path)
+
+    return dataset_dir, output_dir, pretrained_path, cache_dir, dataroot
 
 def script_init():
         # Disable profiling executor

--- a/archai/nlp/nvidia_transformer_xl/nvidia_utils/exp_utils.py
+++ b/archai/nlp/nvidia_transformer_xl/nvidia_utils/exp_utils.py
@@ -257,7 +257,7 @@ def get_create_dirs(dataroot:Optional[str], dataset_name:str,
     dataroot = utils.full_path(dataroot)
 
     dataset_dir = utils.full_path(os.path.join(dataroot,'textpred', dataset_dir_name(dataset_name)))
-    output_dir=  utils.full_path(pt_output_dir or \
+    output_dir = utils.full_path(pt_output_dir or \
                         os.path.join(output_dir, experiment_name)
                     , create=True)
 
@@ -267,7 +267,7 @@ def get_create_dirs(dataroot:Optional[str], dataset_name:str,
     cache_dir = utils.full_path(cache_dir, create=True)
 
     if not os.path.isabs(pretrained_path):
-        pretrained_path = os.path.join(os.path.dirname(pt_output_dir), pretrained_path)
+        pretrained_path = os.path.join(os.path.dirname(output_dir), pretrained_path)
 
     return dataset_dir, output_dir, pretrained_path, cache_dir, dataroot
 

--- a/archai/nlp/nvidia_transformer_xl/qat.py
+++ b/archai/nlp/nvidia_transformer_xl/qat.py
@@ -153,13 +153,8 @@ class FakeQuantEmbedding(torch.nn.Embedding):
 
     @property
     def fake_quant_weight(self):
-        if self.training:
-            return self.weight_fake_quant(self.weight)
+        return self.weight_fake_quant(self.weight)
 
-        if not hasattr(self, '_quant_weight'):
-            self._quant_weight = self.weight_fake_quant(self.weight)
-
-        return self._quant_weight
 
     def forward(self, x):
         return self.fake_quant_weight[x]
@@ -231,13 +226,7 @@ class FakeDynamicQuantLinear(torch.nn.Linear):
 
     @property
     def fake_quant_weight(self):
-        if self.training:
-            return self.weight_fake_quant(self.weight)
-
-        if not hasattr(self, '_quant_weight'):
-            self._quant_weight = self.weight_fake_quant(self.weight)
-
-        return self._quant_weight
+        return self.weight_fake_quant(self.weight)
 
     def forward(self, x):
         x = self.input_pre_process(x)
@@ -326,13 +315,7 @@ class FakeDynamicQuantConv1d(torch.nn.Conv1d):
 
     @property
     def fake_quant_weight(self):
-        if self.training:
-            return self.weight_fake_quant(self.weight)
-
-        if not hasattr(self, '_quant_weight'):
-            self._quant_weight = self.weight_fake_quant(self.weight)
-
-        return self._quant_weight
+        return self.weight_fake_quant(self.weight)
 
     def forward(self, x):
         x = self.input_pre_process(x)
@@ -475,9 +458,10 @@ def float_to_qat_modules(model,
                                  qconfig=qconfig,
                                  **kwargs)
 
-    ProjectedAdaptiveLogSoftmax.hidden_fake_quant = FakeDynamicQuant(dtype=torch.qint8,
+    ProjectedAdaptiveLogSoftmax.hidden_fake_quant = FakeDynamicQuant(reduce_range=False,
                                                                      onnx_compatible=True)
     ProjectedAdaptiveLogSoftmax.weight_fake_quant = FakeDynamicQuant(dtype=torch.qint8,
+                                                                     reduce_range=False,
                                                                      onnx_compatible=True)
     ProjectedAdaptiveLogSoftmax._compute_logit = dynamic_qat_compute_logit
 


### PR DESCRIPTION
Implements Conv1d QAT and QAT finetuning where a pretrained model is loaded.

1. Changes the way cache_dir argument is interpreted. If an absolute path is passed, it will be used as is. If a relative path is passed, it will be joined with 'datadir'. This makes it easy to have multiple caches with different configs. The default behavior remans the same.
2. Adds argument 'pretrained_path' so that we can load a model for finetuning. If an absolute path it will be used as is, if relative it will be joined with the parent folder of 'output_dir'. This allows for local and cluster use.