### PR TITLE
pr(archai): Changes the shape ordering to: batch_size x seq_len.

### DIFF
--- a/archai/nlp/nvidia_transformer_xl/eval.py
+++ b/archai/nlp/nvidia_transformer_xl/eval.py
@@ -259,8 +259,8 @@ def evaluate(eval_iter, model, meters, log_interval, max_size=None, repeat=1):
 
 
 def compile_model(model, device, args):
-    inp = torch.randint(0, 1000, (args.tgt_len, args.batch_size)).to(device)
-    tgt = torch.randint(0, 1000, (args.tgt_len, args.batch_size)).to(device)
+    inp = torch.randint(0, 1000, (args.batch_size, args.tgt_len)).to(device)
+    tgt = torch.randint(0, 1000, (args.batch_size, args.tgt_len)).to(device)
     start = time.time()
     with torch.no_grad():
         mems = None

--- a/archai/nlp/nvidia_transformer_xl/mem_transformer.py
+++ b/archai/nlp/nvidia_transformer_xl/mem_transformer.py
@@ -811,7 +811,7 @@ class MemTransformerLM(nn.Module):
         plen = past_key_values[0][0].size(0) if past_key_values[0] is not None else 0
         klen = mlen + qlen
         if self.same_length:
-            all_ones = word_emb.new_ones(qlen, klen)
+            all_ones = word_emb.new_ones(qlen, klen+plen)
             mask_len = klen - self.mem_len - 1
             if mask_len > 0:
                 mask_shift_len = qlen - mask_len
@@ -821,7 +821,7 @@ class MemTransformerLM(nn.Module):
                              + torch.tril(all_ones, -mask_shift_len)).bool()
         else:
             dec_attn_mask = torch.triu(
-                word_emb.new_ones(qlen, klen), diagonal=1+mlen+plen).bool()
+                word_emb.new_ones(qlen, klen+plen), diagonal=1+mlen+plen).bool()
 
         hids = []
         pasts_key_values = ()

--- a/archai/nlp/nvidia_transformer_xl/mem_transformer.py
+++ b/archai/nlp/nvidia_transformer_xl/mem_transformer.py
@@ -913,6 +913,12 @@ class MemTransformerLM(nn.Module):
         # So, have to initialize size(0) mems inside the model forward.
         # Moreover, have to return new_mems to allow nn.DataParallel to piece
         # them together.
+
+        # Reshapes `data` and `target` to seq_len x batch_size
+        data = data.view(data.size(1), data.size(0))
+        if target is not None:
+            target = target.view(target.size(1), target.size(0))
+
         if mems is None:
             mems = self.init_mems()
 

--- a/archai/nlp/nvidia_transformer_xl/mem_transformer.py
+++ b/archai/nlp/nvidia_transformer_xl/mem_transformer.py
@@ -914,10 +914,10 @@ class MemTransformerLM(nn.Module):
         # Moreover, have to return new_mems to allow nn.DataParallel to piece
         # them together.
 
-        # Reshapes `data` and `target` to seq_len x batch_size
-        data = data.view(data.size(1), data.size(0))
+        # Transposes `data` and `target` to seq_len x batch_size
+        data = data.t()
         if target is not None:
-            target = target.view(target.size(1), target.size(0))
+            target = target.t()
 
         if mems is None:
             mems = self.init_mems()
@@ -941,7 +941,7 @@ class MemTransformerLM(nn.Module):
             loss = -F.log_softmax(logit, -1)[:, :, 0]
         else:
             loss, log_prob = self.crit(hidden=pred_hid.view(-1, pred_hid.size(-1)),
-                                       target=target.view(-1) if target is not None else None,
+                                       target=target.contiguous().view(-1) if target is not None else None,
                                        return_nll=return_nll, return_log_probs=return_log_probs)
             # loss -> [target_len, batch_size]
             # log_prob -> [target_len, batch_size, vocab_size]

--- a/archai/nlp/nvidia_transformer_xl/nvidia_utils/lm_iterators.py
+++ b/archai/nlp/nvidia_transformer_xl/nvidia_utils/lm_iterators.py
@@ -24,13 +24,13 @@ class LMOrderedIterator(object):
         data = data[:n_step * bsz]
 
         # Evenly divide the data across the bsz batches.
-        self.data = data.view(bsz, -1).t().contiguous().pin_memory()
+        self.data = data.view(bsz, -1).contiguous().pin_memory()
 
         if mem_len and warmup:
             self.warmup_batches = (mem_len + bptt - 1) // bptt
             self.warmup_elems = self.warmup_batches * bptt
 
-            warmup_data = self.data.roll((self.warmup_elems, 1), (0, 1))[:self.warmup_elems]
+            warmup_data = self.data.roll((self.warmup_elems, 1), (1, 0))[:self.warmup_elems]
             self.data = torch.cat((warmup_data, self.data))
 
         # Partition data for DistributedDataParallel
@@ -39,30 +39,30 @@ class LMOrderedIterator(object):
         self.data = self.data.chunk(world_size, dim=1)[rank]
 
         # Number of mini-batches
-        self.n_batch = (self.data.size(0) + self.bptt - 1) // self.bptt
+        self.n_batch = (self.data.size(1) + self.bptt - 1) // self.bptt
 
         self.last_iter = None
 
     def roll(self, seed):
         rng = torch.Generator()
         rng.manual_seed(seed)
-        for i in range(self.data.size(1)):
-            row = self.data[:, i]
-            shift = torch.randint(0, self.data.size(0), (1,), generator=rng)
+        for i in range(self.data.size(0)):
+            row = self.data[i, :]
+            shift = torch.randint(0, self.data.size(1), (1,), generator=rng)
             row = torch.cat((row[shift:], row[:shift]))
-            self.data[:, i] = row
+            self.data[i, :] = row
 
     def get_batch(self, i, bptt=None):
         if bptt is None:
             bptt = self.bptt
 
-        seq_len = min(bptt, self.data.size(0) - 1 - i)
+        seq_len = min(bptt, self.data.size(1) - 1 - i)
 
         end_idx = i + seq_len
         beg_idx = max(0, i - self.ext_len)
 
-        data = self.data[beg_idx:end_idx].to(self.device, non_blocking=True)
-        target = self.data[i+1:i+1+seq_len].to(self.device, non_blocking=True)
+        data = self.data[:,beg_idx:end_idx].to(self.device, non_blocking=True)
+        target = self.data[:,i+1:i+1+seq_len].to(self.device, non_blocking=True)
 
         if self.mem_len and self.warmup:
             warm = i >= self.warmup_elems
@@ -74,7 +74,7 @@ class LMOrderedIterator(object):
     def get_fixlen_iter(self, start=0):
         if start != 0:
             start += self.bptt
-        for i in range(start, self.data.size(0) - 1, self.bptt):
+        for i in range(start, self.data.size(1) - 1, self.bptt):
             self.last_iter = i
             yield self.get_batch(i)
 
@@ -87,7 +87,7 @@ class LMOrderedIterator(object):
             data, target, seq_len = self.get_batch(i, bptt)
             i += seq_len
             yield data, target, seq_len
-            if i >= self.data.size(0) - 2:
+            if i >= self.data.size(1) - 2:
                 break
 
     def __iter__(self):
@@ -121,15 +121,15 @@ class LMShuffledIterator(object):
         # streams for each data in the batch
         streams = [None] * self.bsz
 
-        data = torch.LongTensor(self.bptt, self.bsz)
-        target = torch.LongTensor(self.bptt, self.bsz)
+        data = torch.LongTensor(self.bsz, self.bptt)
+        target = torch.LongTensor(self.bsz, self.bptt)
 
         n_retain = 0
 
         while True:
-            # data   : [n_retain+bptt x bsz]
-            # target : [bptt x bsz]
-            data[n_retain:].fill_(-1)
+            # data   : [bsz x n_retain+bptt]
+            # target : [bsz x bptt]
+            data[:, n_retain:].fill_(-1)
             target.fill_(-1)
 
             valid_batch = True
@@ -143,9 +143,9 @@ class LMShuffledIterator(object):
                         # number of new tokens to fill in
                         n_new = min(len(streams[i]) - 1, self.bptt - n_filled)
                         # first n_retain tokens are retained from last batch
-                        data[n_retain+n_filled:n_retain+n_filled+n_new, i] = \
+                        data[i, n_retain+n_filled:n_retain+n_filled+n_new] = \
                             streams[i][:n_new]
-                        target[n_filled:n_filled+n_new, i] = \
+                        target[i, n_filled:n_filled+n_new] = \
                             streams[i][1:n_new+1]
                         streams[i] = streams[i][n_new:]
                         n_filled += n_new
@@ -161,10 +161,10 @@ class LMShuffledIterator(object):
 
             yield data, target, self.bptt
 
-            n_retain = min(data.size(0), self.ext_len)
+            n_retain = min(data.size(1), self.ext_len)
             if n_retain > 0:
-                data[:n_retain] = data[-n_retain:]
-            data.resize_(n_retain + self.bptt, data.size(1))
+                data[:, :n_retain] = data[:, -n_retain:]
+            data.resize_(data.size(0), n_retain + self.bptt)
 
     def __iter__(self):
         # sent_stream is an iterator

--- a/archai/nlp/nvidia_transformer_xl/nvidia_utils/lm_iterators.py
+++ b/archai/nlp/nvidia_transformer_xl/nvidia_utils/lm_iterators.py
@@ -30,8 +30,8 @@ class LMOrderedIterator(object):
             self.warmup_batches = (mem_len + bptt - 1) // bptt
             self.warmup_elems = self.warmup_batches * bptt
 
-            warmup_data = self.data.roll((self.warmup_elems, 1), (1, 0))[:self.warmup_elems]
-            self.data = torch.cat((warmup_data, self.data))
+            warmup_data = self.data.roll((self.warmup_elems, 1), (1, 0))[:, :self.warmup_elems]
+            self.data = torch.cat((warmup_data, self.data), dim=-1)
 
         # Partition data for DistributedDataParallel
         world_size = nv_utils.distributed.get_world_size()

--- a/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/export.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/export.py
@@ -140,11 +140,9 @@ def export_onnx_from_pt(model: MemTransformerLM,
 
     # Exports configuration to JSON
     model_config['model_type'] = 'transfo-xl'
-    #model_config['num_attention_heads'] = n_head
     model_config['past_key_values'] = n_past_values
 
     config_path = Path(onnx_model_path).parent / 'config.json'
-
     with open(config_path, 'w') as f:
         json.dump(model_config, f)
 

--- a/archai/nlp/nvidia_transformer_xl/train.py
+++ b/archai/nlp/nvidia_transformer_xl/train.py
@@ -1183,7 +1183,7 @@ def main():
 
     data, *_ = next(iter(valid_itr))
     model.to('cpu')
-    data = data[:,:1].to('cpu') # make it batch size of one
+    data = data[:1,:].to('cpu') # make it batch size of one
     pt_ops_mem, pt_ops_time, pt_ops_flops, pt_inf_time = ml_perf_utils.inference_stats(model, data=data, target=None, mems=None)
     _, process_mem = ml_perf_utils.model_memory(
         lambda: MemTransformerLM.load_model(checkpoint_path, model=None, on_cpu=True))

--- a/archai/nlp/nvidia_transformer_xl/train.py
+++ b/archai/nlp/nvidia_transformer_xl/train.py
@@ -516,8 +516,8 @@ def train(train_itr, valid_itr, model, para_model, model_config, optimizer,
             param.grad = None
 
         # Splits a tensor into a specific number of chunks. Each chunk is a view of the input tensor.
-        data_chunks = torch.chunk(data, args.batch_chunk, 1)
-        target_chunks = torch.chunk(target, args.batch_chunk, 1)
+        data_chunks = torch.chunk(data, args.batch_chunk, 0)
+        target_chunks = torch.chunk(target, args.batch_chunk, 0)
 
         for i in range(args.batch_chunk):
             # if this is last chunk and distribued mode then use delay_unscale=True for amp

--- a/archai/nlp/scoring/model_wrapper.py
+++ b/archai/nlp/scoring/model_wrapper.py
@@ -38,7 +38,8 @@ class ModelWrapper:
             input_ids = (self.space_token_id,) * (self.max_seq_len - input_ids_len) + input_ids
 
         tokenized_tensor = torch.tensor(input_ids).to(self.device) # pylint: disable=not-callable
-        tokenized_tensor = tokenized_tensor[:, None]  # add batch dimension
+        tokenized_tensor = tokenized_tensor.unsqueeze(0) # add batch dimension
+        
         return tokenized_tensor
 
     def get_loss(self, input_ids: tuple) -> float:


### PR DESCRIPTION
This PR addresses the following issues:

* Changes the shape of input tensors to `[batch_size, seq_len]` instead of the opposite. Such improvement will allow for a more cleaner interface and allow users in using a shape standard that has been proposed by the NLP/Transformer-based community;
* Fixes the creation of `attention_masks` by including the length of `past_key_values` whenever they are used;
* Fixes `wt2` to `wt103` in configuration file. We should be using the same dataset identifier since the file explicitly says that is WikiText-103 for Transformer-XL Base;
* Removes unused key `num_attention_heads` from ONNX export.

*Note that to change the shape of input tensors, several files needed to be modified, including the ones from `scoring` and `nvidia_utils`* packages.