### PR TITLE
pr(archai): Introduces new nomenclature for input and output arguments, more like Huggingface's Transformers.

### DIFF
--- a/archai/nlp/nvidia_transformer_xl/eval.py
+++ b/archai/nlp/nvidia_transformer_xl/eval.py
@@ -198,7 +198,7 @@ def evaluate(eval_iter, model, meters, log_interval, max_size=None, repeat=1):
 
                 torch.cuda.synchronize()
                 start_iter = time.time()
-                loss, mems, _, _ = model(input_ids, labels, mems)
+                loss, _, mems, _ = model(input_ids, labels, mems)
                 torch.cuda.synchronize()
                 elapsed = time.time() - start_iter
 
@@ -259,13 +259,13 @@ def evaluate(eval_iter, model, meters, log_interval, max_size=None, repeat=1):
 
 
 def compile_model(model, device, args):
-    inp = torch.randint(0, 1000, (args.batch_size, args.tgt_len)).to(device)
-    tgt = torch.randint(0, 1000, (args.batch_size, args.tgt_len)).to(device)
+    input_ids = torch.randint(0, 1000, (args.batch_size, args.tgt_len)).to(device)
+    labels = torch.randint(0, 1000, (args.batch_size, args.tgt_len)).to(device)
     start = time.time()
     with torch.no_grad():
         mems = None
         for _ in range(2):
-            _, mems, _, _ = model(inp, tgt, mems)
+            _, _, mems, _ = model(input_ids, labels, mems)
     torch.cuda.synchronize()
     stop = time.time()
     logging.info(f'Building the model took {stop - start:.2f} seconds')

--- a/archai/nlp/nvidia_transformer_xl/eval.py
+++ b/archai/nlp/nvidia_transformer_xl/eval.py
@@ -191,14 +191,14 @@ def evaluate(eval_iter, model, meters, log_interval, max_size=None, repeat=1):
     with torch.no_grad():
         mems = None
         for _ in range(repeat):
-            for idx, (data, target, seq_len, warm) in enumerate(eval_iter):
+            for idx, (input_ids, labels, seq_len, warm) in enumerate(eval_iter):
                 if max_size and idx >= max_size:
                     break
                 eval_step += 1
 
                 torch.cuda.synchronize()
                 start_iter = time.time()
-                loss, mems, _, _ = model(data, target, mems)
+                loss, mems, _, _ = model(input_ids, labels, mems)
                 torch.cuda.synchronize()
                 elapsed = time.time() - start_iter
 
@@ -211,8 +211,8 @@ def evaluate(eval_iter, model, meters, log_interval, max_size=None, repeat=1):
                 meters['eval_latency'].update(elapsed)
                 log_latency += elapsed
 
-                target_tokens = target.numel()
-                throughput = target_tokens / elapsed
+                labels_tokens = labels.numel()
+                throughput = labels_tokens / elapsed
                 throughput = nvidia_utils.distributed.all_reduce_item(throughput, op='sum')
                 meters['eval_throughput'].update(throughput)
                 log_throughput += throughput

--- a/archai/nlp/nvidia_transformer_xl/train.py
+++ b/archai/nlp/nvidia_transformer_xl/train.py
@@ -397,7 +397,7 @@ def evaluate(eval_iter, model, args, eval_nomem=True):
                 break
 
             # first with mem
-            loss, mems, _, _ = model(input_ids, labels, mems)
+            loss, _, mems, _ = model(input_ids, labels, mems)
             loss = loss.float().mean()
             numel = input_ids.numel()
 
@@ -474,7 +474,7 @@ def train_iteration(model, i, mems, input_ids_chunks, labels_chunks, scaler,
         mems[i] = mems[i].to(device, non_blocking=True)
 
     with torch.cuda.amp.autocast(args.fp16):
-        loss, mems[i], _, _ = model(input_ids_i, labels_i, mems[i])
+        loss, _, mems[i], _ = model(input_ids_i, labels_i, mems[i])
         loss = loss.float().mean().type_as(loss) / args.batch_chunk
 
     if args.swap_mem and mems[i] is not None:


### PR DESCRIPTION
Although this PR seems to introduce a bit of changes, they are purely aesthetic to make Archai more compliant with Huggingface's Transformers. Every changed keyword inside `archai/nlp/` has been found and replaced whenever it was needed, while making sure to avoid inner architectural changes, i.e., the changes are mainly in the `MemTransformerLM` class and not in the child-layers classes.

The following changes have been made:

- `data` has been renamed to `input_ids` [1]
- `target` has been renamed to `labels` [1]
- `log_probs` has been renamed to `prediction_scores` [1]
- `return_nll` has been renamed to `output_loss` [1]
- `return_log_probs` has been renamed to `output_prediction_scores` [1]
- MemTransformerLM outputs have been changed from `(loss, mems, prediction_scores, past_key_values)` to `(loss, prediction_scores, mems, past_key_values)` [1]
- Finally, `loss` and `prediction_scores` shapes were asserted to be `[batch_size, seq_len]` instead of `[seq_len, batch_size]`, which was missing from last PR

_The changes have been tested and asserted that the metrics remain the same before/after the PR._

Reference:
[1] https://huggingface.co/transformers/model_doc/transformerxl.html#transformers.TransfoXLLMHeadModel.forward