### PR TITLE
pr(archai): Adds support for configurable ONNX exports.

### DIFF
--- a/archai/nlp/nvidia_transformer_xl/models/archai_model.py
+++ b/archai/nlp/nvidia_transformer_xl/models/archai_model.py
@@ -1,8 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import logging
+import os
 from abc import abstractmethod
 from typing import Optional, Tuple, Type
-
-import os
-import logging
 
 import torch
 import torch.nn as nn
@@ -23,7 +25,7 @@ class ArchaiModel(nn.Module):
         return sum([p.nelement() for p in self.parameters()])
 
     @staticmethod
-    def load_model(model_cls: Type['ArchaiModel'], path:str, model:Optional['ArchaiModel']=None, on_cpu:Optional[bool]=False) -> Tuple['ArchaiModel', dict, dict]:
+    def load_model(model_cls: Type['ArchaiModel'], path:str, model:Optional['ArchaiModel']=None, on_cpu:Optional[bool]=False, on_export:Optional[bool]=False) -> Tuple['ArchaiModel', dict, dict]:
 
         # case for restart
         if os.path.isdir(path):
@@ -31,14 +33,14 @@ class ArchaiModel(nn.Module):
 
         logging.info(f'Loading {model.__class__.__name__} model from: {path}')
 
-        dst = f'cuda:{torch.cuda.current_device()}' \
-            if not on_cpu \
-            else torch.device('cpu')
+        device = f'cuda:{torch.cuda.current_device()}' if not on_cpu and torch.cuda.is_available() else torch.device('cpu')
 
         # Loads the checkpoint
-        checkpoint = torch.load(path, map_location=dst)
-
+        checkpoint = torch.load(path, map_location=device)
         model_config = checkpoint['model_config']
+
+        if on_export:
+            model_config['use_cache'] = True
 
         # Initializes the model
         model = model_cls(**model_config) if model is None else model

--- a/archai/nlp/nvidia_transformer_xl/models/available_models.py
+++ b/archai/nlp/nvidia_transformer_xl/models/available_models.py
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from archai.nlp.nvidia_transformer_xl.models.hf_gpt2 import HfGPT2
+from archai.nlp.nvidia_transformer_xl.models.hf_transfo_xl import HfTransfoXL
+from archai.nlp.nvidia_transformer_xl.models.mem_transformer import MemTransformerLM
+
+# List of available models
+AVAILABLE_MODELS = {
+    'mem_transformer': MemTransformerLM,
+    'hf_gpt2': HfGPT2,
+    'hf_transfo_xl': HfTransfoXL
+}

--- a/archai/nlp/nvidia_transformer_xl/models/hf_gpt2.py
+++ b/archai/nlp/nvidia_transformer_xl/models/hf_gpt2.py
@@ -1,15 +1,14 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 from typing import Optional
 
 import torch
 import torch.nn.functional as F
+from transformers import CONFIG_MAPPING, AutoModelForCausalLM
 
-from transformers import (
-    CONFIG_MAPPING,
-    AutoModelForCausalLM
-)
-
-from archai.nlp.nvidia_transformer_xl.models.model_utils import map_to_list
 from archai.nlp.nvidia_transformer_xl.models.archai_model import ArchaiModel
+from archai.nlp.nvidia_transformer_xl.models.model_utils import map_to_list
 
 
 class HfGPT2(ArchaiModel):

--- a/archai/nlp/nvidia_transformer_xl/models/hf_transfo_xl.py
+++ b/archai/nlp/nvidia_transformer_xl/models/hf_transfo_xl.py
@@ -1,14 +1,13 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 from typing import Optional
 
 import torch
+from transformers import CONFIG_MAPPING, AutoModelForCausalLM
 
-from transformers import (
-    CONFIG_MAPPING,
-    AutoModelForCausalLM
-)
-
-from archai.nlp.nvidia_transformer_xl.models.model_utils import map_to_list
 from archai.nlp.nvidia_transformer_xl.models.archai_model import ArchaiModel
+from archai.nlp.nvidia_transformer_xl.models.model_utils import map_to_list
 
 
 class HfTransfoXL(ArchaiModel):

--- a/archai/nlp/nvidia_transformer_xl/models/model_list.py
+++ b/archai/nlp/nvidia_transformer_xl/models/model_list.py
@@ -1,8 +1,0 @@
-from archai.nlp.nvidia_transformer_xl.models.mem_transformer import MemTransformerLM
-from archai.nlp.nvidia_transformer_xl.models.hf_gpt2 import HfGPT2
-from archai.nlp.nvidia_transformer_xl.models.hf_transfo_xl import HfTransfoXL
-
-# Maps argument string/name to class
-MODEL_LIST = {'mem_transformer': MemTransformerLM,
-              'hf_gpt2': HfGPT2,
-              'hf_transfo_xl': HfTransfoXL}

--- a/archai/nlp/nvidia_transformer_xl/models/model_utils.py
+++ b/archai/nlp/nvidia_transformer_xl/models/model_utils.py
@@ -1,6 +1,19 @@
-from collections.abc import Sized
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
 
-def map_to_list(p, n):
+from collections.abc import Sized
+from typing import Any, List, Union
+
+
+def map_to_list(p: Union[Sized, Any], n: int) -> List[Any]:
+    """Maps variables to lists with fixed lengths.
+
+    Args:
+        p: Variable to be mapped.
+        n: Size of list to be mapped.
+
+    """
+
     if isinstance(p, Sized):
         if len(p) == 1:
             return p * n

--- a/archai/nlp/nvidia_transformer_xl/onnx/export_torch_to_onnx.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/export_torch_to_onnx.py
@@ -20,6 +20,12 @@ def parse_args():
                         type=str,
                         help='Path to the output ONNX model file.')
 
+    parser.add_argument('-model_type',
+                        type=str,
+                        default='mem_transformer',
+                        choices=['mem_transformer', 'hf_gpt2', 'hf_transfo_xl'],
+                        help='Type of model to be exported.')
+
     parser.add_argument('-opt_level',
                         type=int,
                         default=0,
@@ -45,6 +51,7 @@ if __name__ == '__main__':
     # Transforms the command lines arguments into variables
     torch_model_path = args.torch_model_path
     onnx_model_path = args.onnx_model_path
+    model_type = args.model_type
     opt_level = args.opt_level
     optimization = args.optimization
     quantization = args.quantization
@@ -53,11 +60,11 @@ if __name__ == '__main__':
     model, model_config = load_from_pt(torch_model_path)
 
     # Exports to ONNX
-    export_onnx_from_pt(model, model_config, onnx_model_path, share_weights=True)
+    export_onnx_from_pt(model, model_config, model_type, onnx_model_path, share_weights=False)
 
     # Whether optimization should be applied
     if optimization:
-        ort_model_path = optimize_onnx(onnx_model_path, opt_level=opt_level)
+        ort_model_path = optimize_onnx(onnx_model_path, model_type, opt_level=opt_level)
 
         # Caveat to enable quantization after optimization
         onnx_model_path = ort_model_path

--- a/archai/nlp/nvidia_transformer_xl/onnx/export_torch_to_onnx.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/export_torch_to_onnx.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
     quantization = args.quantization
 
     # Loads the PyTorch model
-    model, model_config = load_from_pt(torch_model_path)
+    model, model_config = load_from_pt(model_type, torch_model_path)
 
     # Exports to ONNX
     export_onnx_from_pt(model, model_config, model_type, onnx_model_path, share_weights=False)

--- a/archai/nlp/nvidia_transformer_xl/onnx/export_torch_to_onnx.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/export_torch_to_onnx.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
 
     # Whether optimization should be applied
     if optimization:
-        ort_model_path = optimize_onnx(onnx_model_path, model_type, opt_level=opt_level)
+        ort_model_path = optimize_onnx(model_type, onnx_model_path, opt_level=opt_level)
 
         # Caveat to enable quantization after optimization
         onnx_model_path = ort_model_path

--- a/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/configs.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/configs.py
@@ -1,0 +1,101 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from collections import OrderedDict
+from typing import Any, Dict
+
+import torch
+
+
+class OnnxConfig:
+    """Provides a foundation for creating ONNX-export configuration instances.
+
+    """
+
+    def __init__(self, model_config: str) -> None:
+        """Initializes the configuration.
+
+        Args:
+            model_config: Model configuration.
+
+        """
+
+        self.config = model_config
+
+    @property
+    def mockups(self) -> Dict[str, Any]:
+        """Defines the mockups (inputs) to be used when exporting to ONNX.
+
+        """
+
+        return {
+            'input_ids': torch.randint(0, self.config['n_token'], (1, 32)),
+        }
+
+    @property
+    def inputs(self) -> None:
+        """Defines the inputs and their shapes to be used when exporting to ONNX.
+
+        """
+
+        raise NotImplementedError
+
+    @property
+    def outputs(self) -> None:
+        """Defines the outputs and their shapes to be used when exporting to ONNX.
+        
+        """
+
+        raise NotImplementedError
+
+
+class MemTransformerLMOnnxConfig(OnnxConfig):
+    """Provides an ONNX-export configuration for MemTransformerLM.
+
+    """
+
+    def __init__(self, model_config: str) -> None:
+        """Initializes the configuration.
+
+        Args:
+            model_config: Model configuration.
+
+        """
+
+        super().__init__(model_config)
+
+        if self.config['attn_type'] == 0:
+            self.config['past_key_values'] = 3
+        else:
+            self.config['past_key_values'] = 2
+
+        self.config['model_type'] = 'transfo-xl'
+
+    @property
+    def mockups(self) -> Dict[str, Any]:
+        """Defines the mockups (inputs) to be used when exporting to ONNX.
+        
+        """
+
+        return {
+            'input_ids': torch.randint(0, self.config['n_token'], (1, 32)),
+            'past_key_values': tuple([torch.zeros(self.config['past_key_values'], 1, self.config['n_head'], 32, self.config['d_head']) for _ in range(self.config['n_layer'])])
+        }
+
+    @property
+    def inputs(self) -> OrderedDict:
+        """Defines the inputs and their shapes to be used when exporting to ONNX.
+        
+        """
+
+        pasts = [(f'past_{i}', {0: str(self.config['past_key_values']), 1: 'batch_size', 2: str(self.config['n_head']), 3: 'past_seq_len', 4: str(self.config['d_head'])}) for i in range(self.config['n_layer'])]
+        return OrderedDict([('input_ids', {0: 'batch_size', 1: 'seq_len'})] + pasts)
+
+    @property
+    def outputs(self) -> OrderedDict:
+        """Defines the outputs and their shapes to be used when exporting to ONNX.
+        
+        """
+
+        presents = [(f'present_{i}', {0: str(self.config['past_key_values']), 1: 'batch_size', 2: str(self.config['n_head']), 3: 'total_seq_len', 4: str(self.config['d_head'])}) for i in range(self.config['n_layer'])]
+        return OrderedDict([('probs', {0: 'batch_size', 1: str(self.config['n_token'])})] + presents)

--- a/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/export.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/export.py
@@ -8,7 +8,6 @@ from itertools import chain
 from typing import Optional
 
 import torch
-from archai.nlp.nvidia_transformer_xl.mem_transformer import MemTransformerLM
 from onnx import helper, load_model, numpy_helper, save
 
 from archai.nlp.nvidia_transformer_xl.onnx.onnx_utils.operators import register_trilu_operator
@@ -71,19 +70,21 @@ def weight_sharing(onnx_model_path: str) -> None:
     save(model, onnx_model_path)
 
 
-def export_onnx_from_pt(model: MemTransformerLM,
+def export_onnx_from_pt(model: torch.nn.Module,
                         model_config: dict,
+                        model_type: str,
                         onnx_model_path: str,
                         share_weights: Optional[bool] = True,
                         do_constant_folding: Optional[bool] = True,
                         use_external_data_format: Optional[bool] = False,
                         enable_onnx_checker: Optional[bool] = True,
-                        opset_version: Optional[int] = 12) -> None:
+                        opset_version: Optional[int] = 13) -> None:
     """Exports a PyTorch-based model to ONNX.
 
     Args:
         model: Input model.
         model_config: Model configuration.
+        model_type: Type of model to be exported.
         onnx_model_path: Path to the output ONNX model file.
         share_weights: Whether embedding/softmax weights should be shared.
         do_constant_folding: Whether to apply constant folding.

--- a/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/forward.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/forward.py
@@ -29,7 +29,7 @@ def forward_with_probs(self,
         past_key_values = tuple([p.permute([0, 3, 1, 2, 4]) for p in past_key_values])
 
     # Transposes to seq_len x batch_size
-    input_ids = input_ids = input_ids.t()
+    input_ids = input_ids.t()
 
     # Gathers the hidden states
     # Note that we are only exporting the final probability
@@ -40,6 +40,7 @@ def forward_with_probs(self,
 
     # Calculates the output predictions/probabilities
     preds = self.crit(hidden_preds)
+    preds = preds.view(input_ids.size(1), -1) if preds is not None else None
 
     # Reshapes past_key_values back to standard shape
     past_key_values = tuple([p.permute([0, 2, 3, 1, 4]) for p in past_key_values])

--- a/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/forward.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/forward.py
@@ -28,8 +28,8 @@ def forward_with_probs(self,
     else:
         past_key_values = tuple([p.permute([0, 3, 1, 2, 4]) for p in past_key_values])
 
-    # Reshapes to seq_len x batch_size
-    input_ids = input_ids.view(input_ids.size(1), input_ids.size(0))
+    # Transposes to seq_len x batch_size
+    input_ids = input_ids = input_ids.t()
 
     # Gathers the hidden states
     # Note that we are only exporting the final probability

--- a/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/load.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/load.py
@@ -10,7 +10,7 @@ import torch
 from onnxruntime import (GraphOptimizationLevel, InferenceSession,
                          SessionOptions)
 
-from archai.nlp.nvidia_transformer_xl.mem_transformer import MemTransformerLM
+from archai.nlp.nvidia_transformer_xl.models.mem_transformer import MemTransformerLM
 from archai.nlp.nvidia_transformer_xl.onnx.onnx_utils.forward import (crit_forward_with_probs,
                                                                       forward_with_probs)
 

--- a/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/load.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/load.py
@@ -6,11 +6,11 @@ from os import environ
 from pathlib import Path
 from typing import Tuple
 
-import torch
 from onnxruntime import (GraphOptimizationLevel, InferenceSession,
                          SessionOptions)
+from archai.nlp.nvidia_transformer_xl.models.archai_model import ArchaiModel
+from archai.nlp.nvidia_transformer_xl.models.available_models import AVAILABLE_MODELS
 
-from archai.nlp.nvidia_transformer_xl.models.mem_transformer import MemTransformerLM
 from archai.nlp.nvidia_transformer_xl.onnx.onnx_utils.forward import (crit_forward_with_probs,
                                                                       forward_with_probs)
 
@@ -59,38 +59,30 @@ def load_from_onnx(onnx_model_path: str) -> InferenceSession:
     return session
 
 
-def load_from_pt(torch_model_path: str) -> Tuple[MemTransformerLM, dict]:
+def load_from_pt(model_type: str, torch_model_path: str) -> Tuple[ArchaiModel, dict]:
     """Loads a PyTorch-based model from checkpoint.
 
     Args:
+        model_type: Type of model to be loaded.
         torch_model_path: Path to the PyTorch model/checkpoint file.
 
     Returns:
-        (MemTransformerLM, dict): PyTorch model and its configuration.
+        (ArchaiModel, dict): PyTorch model and its configuration.
 
     """
 
-    # Loads the checkpoint
-    # Note we are always enabling cache for usage of `past_key_values`
-    checkpoint = torch.load(torch_model_path, map_location=torch.device('cpu'))
-    checkpoint['model_config']['use_cache'] = True
+    # Loads the model
+    model, model_config, _ = ArchaiModel.load_model(AVAILABLE_MODELS[model_type],
+                                                    torch_model_path,
+                                                    on_cpu=False,
+                                                    on_export=True)
 
-    # Initializes the model
-
-    # Added for compatibility with models trained with an 
-    # older test branch which had this flag
-    # TODO: Remove in the future
-    if 'encoder_like' in checkpoint['model_config']:
-        del checkpoint['model_config']['encoder_like']
-    
-    model = MemTransformerLM(**checkpoint['model_config'])
-    model.load_state_dict(checkpoint['model_state'])
-
-    # Overrides forward functions
-    model.forward = types.MethodType(forward_with_probs, model)
-    model.crit.forward = types.MethodType(crit_forward_with_probs, model.crit)
+    # Overrides forward functions if MemTransformerLM
+    if model_type == 'mem_transformer':
+        model.forward = types.MethodType(forward_with_probs, model)
+        model.crit.forward = types.MethodType(crit_forward_with_probs, model.crit)
 
     # Puts to evaluation model to disable dropout
     model.eval()
 
-    return model, checkpoint['model_config']
+    return model, model_config

--- a/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/opt/fusion_options.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/opt/fusion_options.py
@@ -20,19 +20,31 @@ class FusionOptions:
 
     """
 
-    def __init__(self) -> None:
+    def __init__(self, model_type: str) -> None:
         """Defines an initialization method.
+
+        Args:
+            model_type: Type of model to be fused.
 
         """
 
+        # GeLU
+        self.enable_gelu = True
+        self.enable_bias_gelu = True
+        self.enable_gelu_approximation = False
+
         # Layer normalization
         self.enable_layer_norm = True
+        self.enable_embed_layer_norm = True
         self.enable_skip_layer_norm = True
         self.enable_bias_skip_layer_norm = True
 
         # Attention
         self.enable_attention = True
         self.attention_mask_format = AttentionMaskFormat.AttentionMask
+
+        if model_type == 'hf_gpt2':
+            self.enable_skip_layer_norm = False
 
     def use_raw_attention_mask(self,
                                use_raw_mask: Optional[bool] = True) -> None:

--- a/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/opt/opt_models.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/opt/opt_models.py
@@ -5,13 +5,11 @@ from typing import List, Optional, Tuple
 
 from onnx import (GraphProto, ModelProto, NodeProto, TensorProto,
                   ValueInfoProto, helper)
-from onnxruntime.transformers.fusion_attention import (AttentionMask,
-                                                       FusionAttention)
+from onnxruntime.transformers.fusion_attention import AttentionMask, FusionAttention
 from onnxruntime.transformers.fusion_layernorm import FusionLayerNormalization
 from onnxruntime.transformers.fusion_reshape import FusionReshape
 from onnxruntime.transformers.fusion_shape import FusionShape
-from onnxruntime.transformers.fusion_skiplayernorm import (FusionBiasSkipLayerNormalization,
-                                                           FusionSkipLayerNormalization)
+from onnxruntime.transformers.fusion_skiplayernorm import FusionBiasSkipLayerNormalization, FusionSkipLayerNormalization
 from onnxruntime.transformers.fusion_utils import FusionUtils
 from onnxruntime.transformers.onnx_model import OnnxModel
 

--- a/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/optimization.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/optimization.py
@@ -13,15 +13,15 @@ from archai.nlp.nvidia_transformer_xl.onnx.onnx_utils.opt.fusion_options import 
 from archai.nlp.nvidia_transformer_xl.onnx.onnx_utils.opt.opt_models import MemTransformerLMOnnxModel
 
 # List of available ONNX models to be optimized
-AVAILABLE_ONNX_OPT_MODELS = {
+AVAILABLE_ONNX_OPTS = {
     'mem_transformer': MemTransformerLMOnnxModel,
     'hf_gpt2': Gpt2OnnxModel,
     'hf_transfo_xl': MemTransformerLMOnnxModel
 }
 
 
-def optimize_onnx(onnx_model_path: str,
-                  model_type: str,
+def optimize_onnx(model_type: str,
+                  onnx_model_path: str,
                   use_gpu: Optional[bool] = False,
                   opt_level: Optional[int] = 0,
                   only_ort: Optional[bool] = False,
@@ -30,8 +30,8 @@ def optimize_onnx(onnx_model_path: str,
     """Optimizes an ONNX model.
 
     Args:
-        onnx_model_path: Path to the ONNX model to be optimized.
         model_type: Type of model to be optimized.
+        onnx_model_path: Path to the ONNX model to be optimized.
         use_gpu: Whether to use GPU during optimization.
         opt_level: Level of optimization.
         only_ort: Whether to only apply ORT optimization.
@@ -70,7 +70,7 @@ def optimize_onnx(onnx_model_path: str,
         # Loads the ORT-optimized model, optimizer and fusion options
         ort_model = load_model(ort_model_path or onnx_model_path)
         ort_model_path = create_file_name_identifier(Path(onnx_model_path), '_opt')
-        optimizer = AVAILABLE_ONNX_OPT_MODELS[model_type](ort_model)
+        optimizer = AVAILABLE_ONNX_OPTS[model_type](ort_model)
         options = FusionOptions(model_type)
 
         # Optimizes the model

--- a/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/optimization.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/onnx_utils/optimization.py
@@ -10,11 +10,14 @@ from onnxruntime.transformers.optimizer import optimize_by_onnxruntime
 
 from archai.nlp.nvidia_transformer_xl.onnx.onnx_utils.load import create_file_name_identifier
 from archai.nlp.nvidia_transformer_xl.onnx.onnx_utils.opt.fusion_options import FusionOptions
-from archai.nlp.nvidia_transformer_xl.onnx.onnx_utils.opt.model import MemTransformerLMOnnxModel
+from archai.nlp.nvidia_transformer_xl.onnx.onnx_utils.opt.opt_models import MemTransformerLMOnnxModel
 
-ONNX_MODELS = {'mem_transformer': MemTransformerLMOnnxModel,
-               'hf_gpt2': Gpt2OnnxModel,
-               'hf_transfo_xl': MemTransformerLMOnnxModel}
+# List of available ONNX models to be optimized
+AVAILABLE_ONNX_OPT_MODELS = {
+    'mem_transformer': MemTransformerLMOnnxModel,
+    'hf_gpt2': Gpt2OnnxModel,
+    'hf_transfo_xl': MemTransformerLMOnnxModel
+}
 
 
 def optimize_onnx(onnx_model_path: str,
@@ -67,7 +70,7 @@ def optimize_onnx(onnx_model_path: str,
         # Loads the ORT-optimized model, optimizer and fusion options
         ort_model = load_model(ort_model_path or onnx_model_path)
         ort_model_path = create_file_name_identifier(Path(onnx_model_path), '_opt')
-        optimizer = ONNX_MODELS[model_type](ort_model)
+        optimizer = AVAILABLE_ONNX_OPT_MODELS[model_type](ort_model)
         options = FusionOptions(model_type)
 
         # Optimizes the model

--- a/archai/nlp/nvidia_transformer_xl/onnx/validate_onnx_export.py
+++ b/archai/nlp/nvidia_transformer_xl/onnx/validate_onnx_export.py
@@ -19,6 +19,12 @@ def parse_args():
                         type=str,
                         help='Path to the ONNX model file.')
 
+    parser.add_argument('-model_type',
+                        type=str,
+                        default='mem_transformer',
+                        choices=['mem_transformer', 'hf_gpt2', 'hf_transfo_xl'],
+                        help='Type of model to be exported.')
+
     parser.add_argument('-batch_size',
                         type=int,
                         default=1,
@@ -41,11 +47,12 @@ if __name__ == '__main__':
     # Transforms the command lines arguments into variables
     torch_model_path = args.torch_model_path
     onnx_model_path = args.onnx_model_path
+    model_type = args.model_type
     batch_size = args.batch_size
     seq_len = args.seq_len
 
     # Loads PyTorch and ONNX models
-    model, model_config = load_from_pt(torch_model_path)
+    model, model_config = load_from_pt(model_type, torch_model_path)
     model_onnx = load_from_onnx(onnx_model_path)
 
     # Checks the type of attention to define the `past_key_values`

--- a/archai/nlp/nvidia_transformer_xl/train.py
+++ b/archai/nlp/nvidia_transformer_xl/train.py
@@ -26,7 +26,7 @@ from torch.nn.parallel import DistributedDataParallel
 from archai.nlp.nvidia_transformer_xl import lamb
 from archai.nlp.nvidia_transformer_xl.data_utils import get_lm_corpus
 from archai.nlp.nvidia_transformer_xl.models.archai_model import ArchaiModel
-from archai.nlp.nvidia_transformer_xl.models.model_list import MODEL_LIST
+from archai.nlp.nvidia_transformer_xl.models.available_models import AVAILABLE_MODELS
 from archai.nlp.nvidia_transformer_xl.nvidia_utils import distributed as nv_distributed
 from archai.nlp.nvidia_transformer_xl.nvidia_utils.cyclic_cosine_scheduler import CyclicCosineDecayLR
 from archai.nlp.nvidia_transformer_xl.nvidia_utils.data_parallel import BalancedDataParallel
@@ -859,9 +859,9 @@ def create_or_load_model(args, device, ntokens)->Tuple[ArchaiModel, dict]:
 
     if args.pretrained_path:
         logging.info('Overwriting the provided model config with the pretrained model config.')
-        model, model_config, checkpoint = ArchaiModel.load_model(MODEL_LIST[args.model], args.pretrained_path, on_cpu=False)
+        model, model_config, checkpoint = ArchaiModel.load_model(AVAILABLE_MODELS[args.model], args.pretrained_path, on_cpu=False)
     else:
-        model_cls = MODEL_LIST[args.model]
+        model_cls = AVAILABLE_MODELS[args.model]
         model = model_cls(**model_config)
 
     if args.qat:
@@ -1028,7 +1028,7 @@ def train_main(args, device, train_itr, valid_itr, model, para_model, model_conf
 
     if args.restart:
         try:
-            model, model_config, checkpoint = ArchaiModel.load_model(MODEL_LIST[args.model], args.restart, model, on_cpu=False)
+            model, model_config, checkpoint = ArchaiModel.load_model(AVAILABLE_MODELS[args.model], args.restart, model, on_cpu=False)
             optimizer.load_state_dict(checkpoint['optimizer_state'])
             scheduler.load_state_dict(checkpoint['scheduler_state'])
             if args.fp16:
@@ -1109,7 +1109,7 @@ def evaluate_main(args, model, checkpoint_path:str, test_itr, test_file_stats):
 
     if not args.no_eval and os.path.exists(checkpoint_path):
         # Load the best saved model.
-        model, model_config, checkpoint = ArchaiModel.load_model(MODEL_LIST[args.model], checkpoint_path, model, on_cpu=False)
+        model, model_config, checkpoint = ArchaiModel.load_model(AVAILABLE_MODELS[args.model], checkpoint_path, model, on_cpu=False)
 
         # Run on test data.
         test_start_time = time.time()
@@ -1193,7 +1193,7 @@ def main():
     input_ids = input_ids[:1,:].to('cpu') # make it batch size of one
     pt_ops_mem, pt_ops_time, pt_ops_flops, pt_inf_time = ml_perf_utils.inference_stats(model, input_ids=input_ids, labels=None, mems=None)
     _, process_mem = ml_perf_utils.model_memory(
-        lambda: ArchaiModel.load_model(MODEL_LIST[args.model], checkpoint_path, model=None, on_cpu=True))
+        lambda: ArchaiModel.load_model(AVAILABLE_MODELS[args.model], checkpoint_path, model=None, on_cpu=True))
 
     summary.update({
         'experiment_name': args.experiment_name,
@@ -1243,7 +1243,7 @@ def main():
 
     if args.post_qat:
         # Loads the model from the best pre-trained checkpoint
-        model, model_config, checkpoint = ArchaiModel.load_model(MODEL_LIST[args.model], checkpoint_path, model, on_cpu=False)
+        model, model_config, checkpoint = ArchaiModel.load_model(AVAILABLE_MODELS[args.model], checkpoint_path, model, on_cpu=False)
 
         # Prepares the model with QAT (also allows for distributed training)
         model = prepare_with_qat(model, onnx_compatible=True)


### PR DESCRIPTION
This PR introduces the following changes:

- Adds license headers to new files;
- Fixes a bug when loading an `ArchaiModel` and not having PyTorch compiled with CUDA;
- Changes `models/model_list.py` to `models/available_models.py`;
- Allows for configurable ONNX exports;
- Allows for configurable ONNX optimizations.

_The order of PR merges should be the following: `gderosa/onnx_export` into `gderosa/transfo_xl` before `gderosa/transfo_xl` into `nlp`._