### PR TITLE
Fixed naming and converts Conv1D to linear

### DIFF
--- a/archai/nlp/compression/onnx/onnx_utils/export.py
+++ b/archai/nlp/compression/onnx/onnx_utils/export.py
@@ -88,7 +88,7 @@ def weight_sharing(onnx_model_path: str, model_type: str) -> None:
     save(model, onnx_model_path)
 
 
-def export_onnx_from_pt(model: torch.nn.Module,
+def export_onnx_from_torch(model: torch.nn.Module,
                         model_config: dict,
                         model_type: str,
                         onnx_model_path: str,

--- a/archai/nlp/compression/onnx/onnx_utils/onnx_loader.py
+++ b/archai/nlp/compression/onnx/onnx_utils/onnx_loader.py
@@ -88,7 +88,7 @@ def load_from_torch_for_export(model_type: str, torch_model_path: str) -> Tuple[
         model = model.model
         model.forward = types.MethodType(forward_gpt2_onnx, model)
 
-        # if we dont do this the export/fusion operations break
+        # if we dont do this the export/fusion operations break with relu squared
         for layer in model.transformer.h:
             quantize_helper.conv1d_to_linear(layer.mlp)
 

--- a/archai/nlp/compression/onnx/onnx_utils/onnx_loader.py
+++ b/archai/nlp/compression/onnx/onnx_utils/onnx_loader.py
@@ -9,6 +9,8 @@ from typing import Tuple
 from onnxruntime import (GraphOptimizationLevel, InferenceSession,
                          SessionOptions)
 
+from onnxruntime.transformers import quantize_helper
+
 from archai.nlp.models.archai_model import ArchaiModel
 from archai.nlp.models.available_models import AVAILABLE_MODELS
 from archai.nlp.compression.onnx.onnx_utils.forward import (crit_forward_memformer_onnx, forward_gpt2_onnx,
@@ -59,7 +61,7 @@ def load_from_onnx(onnx_model_path: str) -> InferenceSession:
     return session
 
 
-def load_from_pt(model_type: str, torch_model_path: str) -> Tuple[ArchaiModel, dict]:
+def load_from_torch_for_export(model_type: str, torch_model_path: str) -> Tuple[ArchaiModel, dict]:
     """Loads a PyTorch-based model from checkpoint.
 
     Args:
@@ -86,9 +88,14 @@ def load_from_pt(model_type: str, torch_model_path: str) -> Tuple[ArchaiModel, d
         model = model.model
         model.forward = types.MethodType(forward_gpt2_onnx, model)
 
+        for layer in model.transformer.h:
+            quantize_helper.conv1d_to_linear(layer.mlp)
+
     if type(model_config['d_head']) is list:
+        assert all(model_config['d_head'][0] == d_head for d_head in model_config['d_head']), 'We do not support different number of heads for export.'
         model_config['d_head'] = model_config['d_head'][0]
     if type(model_config['n_head']) is list:
+        assert all(model_config['n_head'][0] == d_head for d_head in model_config['n_head']), 'We do not support different number of heads for export.'
         model_config['n_head'] = model_config['n_head'][0]
 
     # Puts to evaluation model to disable dropout

--- a/archai/nlp/compression/onnx/onnx_utils/onnx_loader.py
+++ b/archai/nlp/compression/onnx/onnx_utils/onnx_loader.py
@@ -88,6 +88,7 @@ def load_from_torch_for_export(model_type: str, torch_model_path: str) -> Tuple[
         model = model.model
         model.forward = types.MethodType(forward_gpt2_onnx, model)
 
+        # if we dont do this the export/fusion operations break
         for layer in model.transformer.h:
             quantize_helper.conv1d_to_linear(layer.mlp)
 

--- a/archai/nlp/compression/quantization/modules.py
+++ b/archai/nlp/compression/quantization/modules.py
@@ -513,7 +513,7 @@ class FakeDynamicQuantHFConv1D(transformers.modeling_utils.Conv1D):
 
         weight = self.weight_fake_quant(self.weight)
 
-        float_conv1d = transformers.modeling_utils.conv1d(self.nf,
+        float_conv1d = transformers.modeling_utils.Conv1D(self.nf,
                                                           self.weight.shape[0])
 
         float_conv1d.weight = torch.nn.Parameter(weight)


### PR DESCRIPTION
1. Fixes naming issues
2. Converts H.F. "Conv1D" to linear to avoid export break with relu squared.
