### PR TITLE
Partial fix on # params GPT2Flex and default param

### DIFF
--- a/archai/nlp/models/hf_gpt2/model_hf_gpt2.py
+++ b/archai/nlp/models/hf_gpt2/model_hf_gpt2.py
@@ -189,9 +189,9 @@ class HfGPT2Flex(ArchaiModel):
     def get_params(self) -> Dict[str, int]:
         params = {}
 
-        params['embedding'] = self.get_params_from_layer(['nn.Embedding'])
+        params['embedding'] = self.get_params_from_layer(['Embedding'])
         params['attention'] = self.get_params_from_layer(['GPT2Attention'])
-        params['ff'] = self.get_params_from_layer(['GPT2MLP'])
+        params['ff'] = self.get_params_from_layer(['GPT2MLPFlex'])
 
         params['non_embedding'] = params['attention'] + params['ff']
         params['total'] = params['non_embedding'] + params['embedding']

--- a/archai/nlp/models/model_mixed_qat.py
+++ b/archai/nlp/models/model_mixed_qat.py
@@ -48,5 +48,5 @@ class MixedQATModel(ArchaiModel):
     def reset_length(self, *args, **kwargs):
         return self.model.reset_length(*args, **kwargs)
 
-    def get_non_emb_params(self):
-        return self.model.get_non_emb_params()
+    def get_params(self):
+        return self.model.get_params()

--- a/archai/nlp/train.py
+++ b/archai/nlp/train.py
@@ -202,7 +202,7 @@ def parse_args():
     opt.add_argument('--scheduler', default='cosine', type=str,
                      choices=['cosine', 'inv_sqrt', 'dev_perf', 'constant', 'cyclic_cosine'],
                      help='LR scheduler to use')
-    opt.add_argument('--scheduler_qat', default='cyclic_cosine', type=str,
+    opt.add_argument('--scheduler_qat', default='cosine', type=str,
                      choices=['cosine', 'inv_sqrt', 'dev_perf', 'constant', 'cyclic_cosine'],
                      help='LR scheduler to use during QAT')
     opt.add_argument('--max_step_scheduler', type=int, default=None,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires=[
     'requests', 'seaborn', 'h5py', 'rarfile',
     'gorilla', 'pyyaml', 'overrides', 'runstats', 'psutil', 'statopt',
     'pyunpack', 'patool', 'ray>=1.0.0', 'Send2Trash',
-    'transformers>=4.15.0', 'pytorch_lightning', 'tokenizers>>=0.10.3', 'datasets',
+    'transformers>=4.15.0', 'pytorch_lightning', 'tokenizers>=0.10.3', 'datasets',
     'onnx', 'onnxruntime', 'coloredlogs', 'sympy',
     'ftfy', # needed for text scoring, fixes text for you
     # nvidia transformer-xl


### PR DESCRIPTION
1. Partial fix on GPT2Flex # of params (there's still a small diff compared to previous code)
2. Changes default qat scheduler (we won't be using cyclic_cosine anymore)