### PR TITLE
Fixing archai/devops workflow

### DIFF
--- a/devops/azure/runner.py
+++ b/devops/azure/runner.py
@@ -382,6 +382,8 @@ def run_model(name, snpe_root, dataset, conn_string, use_device, benchmark_only,
 
     if not converted and onnx_model_found:
         model = convert(name, entity, long_name, onnx_model)
+        if model == 'error':
+            return
     elif converted:
         model_found, long_name, model = download_model(name, snpe_model_dir, conn_string, 'model.dlc')
         if not model_found:
@@ -558,10 +560,11 @@ def find_work_prioritized(use_device, benchmark_only, subset_list, no_quantizati
             log(f"# skipping {name} because something went wrong on previous step.")
             continue
         if not is_complete(entity, 'macs') or not is_true(entity, 'quantized'):
-            if not no_quantization:
-                continue
             if quantizing:
-                log(f"skip {name} for now until other quantization finishes on our node")
+                if no_quantization:
+                    log(f"No quantization work is done on this node. Skip {name} for now until other node works on it.")
+                else:
+                    log(f"skip {name} for now until other quantization finishes on our node")
                 continue
             priority = 20
         elif use_device and (total_benchmark_runs < MAX_BENCHMARK_RUNS):

--- a/devops/azure/upload.py
+++ b/devops/azure/upload.py
@@ -6,7 +6,7 @@ import random
 import sys
 import platform
 from azure.storage.blob import BlobClient, ContainerClient
-from status import get_status, merge_status_entity, get_all_status_entities, get_utc_date
+from status import get_status, update_status_entity, get_all_status_entities, get_utc_date
 from reset import reset_metrics
 from delete import delete_blobs
 
@@ -74,7 +74,7 @@ def upload(model, name, priority=None, benchmark_only=False, use_pillow=False):
 
     e['status'] = 'uploading'
     e['node'] = get_node_id()  # lock the row until upload complete
-    merge_status_entity(e)
+    update_status_entity(e)
     try:
         upload_blob(name, model)
         # remove any cached dlc files since they need to be redone now.
@@ -95,7 +95,7 @@ def upload(model, name, priority=None, benchmark_only=False, use_pillow=False):
     if use_pillow:
         e['use_pillow'] = 1 if use_pillow else 0
 
-    merge_status_entity(e)
+    update_status_entity(e)
 
 
 if __name__ == '__main__':

--- a/devops/requirements.txt
+++ b/devops/requirements.txt
@@ -1,7 +1,7 @@
 sphinx==4.5.0
 scipy==1.5.4
 matplotlib==3.3.4
-scikit-image==0.19.3
+scikit-image==0.17.2
 pyyaml==6.0
 numpy
 onnx==1.11.0


### PR DESCRIPTION
## Description

requirements.txt
- Changed scikit-image version to match Python 3.6

upload.py
- Resource not found when uploading a model. Fixed by using update_status_entity();
- Node column in Azure Table was populated with the local machine's name, locking the workflow. Fixed by using update_status_entity()

runner.py

- All rows are getting skipped due to: _skip <model-name> for now until other quantization finishes on our node_. Although the model is already quantized, the column is not set as true. Fixed by correcting the logic of quantization verification.
- When there's a conversion error (e.g. onnx to dlc), the next state of the Azure Table does not reflect that. It gets stuck on "quantizing" or other unrelated status. Fixed by adding error checks.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)