### PR TITLE
fix(docs): Fixes order of autodoc_mock_imports in conf.py.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ html_theme_options = {
 # Autodoc
 autodoc_default_options = {"exclude-members": "__weakref__"}
 autodoc_member_order = "bysource"
-autodoc_mock_imports = ["xautodl", "ray.tune"]
+autodoc_mock_imports = ["ray.tune", "xautodl"]
 
 # Disables `nbsphinx` require.js to avoid
 # conflicts with `sphinxcontrib.mermaid`


### PR DESCRIPTION
# Pull Request Template

## Description

Updates a single `conf.py` with the correct order of `autodoc_mock_imports` and activates the documentation workflow.

## Changes

- [X] Documentation update


**Configuration**:
* Archai version: 1.0.0
* Environment: Python 3.7
* OS: Windows 11

## Final checks:

- [X] Follows guidelines of project
- [X] Self-review of code
- [X] Commented code in hard-to-understand areas
- [X] Corresponding changes to the documentation
- [X] Changes generate no new warnings
- [X] Dependent changes have already been merged
- [X] Checked code correction any misspellings