### PR TITLE
pr(archai): Improves ONNX-based evaluators.

### DIFF
--- a/archai/discrete_search/evaluators/nlp/transformer_flex_latency.py
+++ b/archai/discrete_search/evaluators/nlp/transformer_flex_latency.py
@@ -2,9 +2,10 @@
 # Licensed under the MIT license.
 
 import copy
-import os
+import pathlib
+import shutil
 import timeit
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import torch
@@ -23,6 +24,8 @@ from archai.onnx.export_utils import prepare_model_for_onnx
 from archai.onnx.onnx_loader import load_from_onnx
 from archai.onnx.optimization import optimize_onnx
 
+TMP_FOLDER = pathlib.Path("tmp")
+
 
 class TransformerFlexOnnxLatency(ModelEvaluator):
     """Measure the average latency of models from the Transformer-Flex search space."""
@@ -30,20 +33,24 @@ class TransformerFlexOnnxLatency(ModelEvaluator):
     def __init__(
         self,
         search_space: TransformerFlexSearchSpace,
+        providers: Optional[List[str]] = None,
         batch_size: Optional[int] = 1,
         seq_len: Optional[int] = 192,
         past_seq_len: Optional[int] = 0,
         n_trials: Optional[int] = 1,
         use_median: Optional[bool] = False,
         use_past: Optional[bool] = True,
+        validate: Optional[bool] = True,
         share_weights: Optional[bool] = True,
         opset: Optional[int] = 11,
+        optimize: Optional[bool] = True,
         only_ort: Optional[bool] = False,
     ) -> None:
         """Initialize the evaluator.
 
         Args:
             search_space: The search space to use for loading the model.
+            providers: The list of ORT providers to use for benchmarking.
             batch_size: The batch size to use when benchmarking the model.
             seq_len: The sequence length to use when benchmarking the model.
             past_seq_len: The past sequence length to use when benchmarking the model.
@@ -51,8 +58,10 @@ class TransformerFlexOnnxLatency(ModelEvaluator):
             use_median: Whether to use the median or the mean of the measured
                 times as the result.
             use_past: Whether to include past key/values in the model.
+            validate: Whether to validate the exported model.
             share_weights: Whether to share the embedding and softmax weights.
             opset: Set of operations to use with ONNX.
+            optimize: Whether to optimize the ONNX model.
             only_ort: Whether to only apply ORT optimization.
 
         """
@@ -61,14 +70,17 @@ class TransformerFlexOnnxLatency(ModelEvaluator):
         self.search_space = search_space
 
         # Benchmark settings
+        self.providers = providers
         self.batch_size = batch_size
         self.seq_len = seq_len
         self.past_seq_len = past_seq_len
         self.n_trials = n_trials
         self.use_median = use_median
         self.use_past = use_past
+        self.validate = validate
         self.share_weights = share_weights
         self.opset = opset
+        self.optimize = optimize
         self.only_ort = only_ort
 
     def _load_and_prepare(self, config: Dict[str, Any]) -> torch.nn.Module:
@@ -108,25 +120,25 @@ class TransformerFlexOnnxLatency(ModelEvaluator):
 
         # There is a bug for Python < 3.10 when using TemporaryFile with Windows,
         # thus, we opted to manually save and remove the temporary file
-        tmp_path = "tmp.onnx"
+        TMP_FOLDER.mkdir(parents=True, exist_ok=True)
+        onnx_path = TMP_FOLDER / "model.onnx"
 
         onnx_config = export_to_onnx(
             model,
-            tmp_path,
+            onnx_path.as_posix(),
             task="causal-lm",
             use_past=self.use_past,
+            validate=self.validate,
             share_weights=self.share_weights,
             opset=self.opset,
         )
-        opt_tmp_path = optimize_onnx(tmp_path, onnx_config, opt_level=0, only_ort=self.only_ort)
 
-        session = load_from_onnx(opt_tmp_path)
+        if self.optimize:
+            onnx_path = optimize_onnx(onnx_path.as_posix(), onnx_config, opt_level=0, only_ort=self.only_ort)
+
+        session = load_from_onnx(onnx_path, providers=self.providers)
         latency = self._benchmark_model(session, onnx_config)
 
-        try:
-            os.remove(tmp_path)
-            os.remove(opt_tmp_path)
-        except FileNotFoundError:
-            pass
+        shutil.rmtree(TMP_FOLDER)
 
         return latency

--- a/archai/discrete_search/evaluators/nlp/transformer_flex_latency.py
+++ b/archai/discrete_search/evaluators/nlp/transformer_flex_latency.py
@@ -48,6 +48,10 @@ class TransformerFlexOnnxLatency(ModelEvaluator):
     ) -> None:
         """Initialize the evaluator.
 
+        This evaluator supports measuring in different ONNX Runtime providers. For measuring on
+        GPUs, use `providers=["CUDAExecutionProvider"]` and make sure that `onnxruntime-gpu`
+        package is installed.
+
         Args:
             search_space: The search space to use for loading the model.
             providers: The list of ORT providers to use for benchmarking.

--- a/archai/discrete_search/evaluators/nlp/transformer_flex_memory.py
+++ b/archai/discrete_search/evaluators/nlp/transformer_flex_memory.py
@@ -2,7 +2,8 @@
 # Licensed under the MIT license.
 
 import copy
-import os
+import pathlib
+import shutil
 from typing import Any, Dict, Optional
 
 import torch
@@ -18,6 +19,8 @@ from archai.onnx.export import export_to_onnx
 from archai.onnx.export_utils import prepare_model_for_onnx
 from archai.onnx.optimization import optimize_onnx
 
+TMP_FOLDER = pathlib.Path("tmp")
+
 
 class TransformerFlexOnnxMemory(ModelEvaluator):
     """Measure the memory usage of models from the Transformer-Flex search space."""
@@ -26,8 +29,10 @@ class TransformerFlexOnnxMemory(ModelEvaluator):
         self,
         search_space: TransformerFlexSearchSpace,
         use_past: Optional[bool] = True,
+        validate: Optional[bool] = True,
         share_weights: Optional[bool] = True,
         opset: Optional[int] = 11,
+        optimize: Optional[bool] = True,
         only_ort: Optional[bool] = False,
     ) -> None:
         """Initialize the evaluator.
@@ -35,8 +40,10 @@ class TransformerFlexOnnxMemory(ModelEvaluator):
         Args:
             search_space: The search space to use for loading the model.
             use_past: Whether to include past key/values in the model.
+            validate: Whether to validate the exported model.
             share_weights: Whether to share the embedding and softmax weights.
             opset: Set of operations to use with ONNX.
+            optimize: Whether to optimize the ONNX model.
             only_ort: Whether to only apply ORT optimization.
 
         """
@@ -46,8 +53,10 @@ class TransformerFlexOnnxMemory(ModelEvaluator):
 
         # Benchmark settings
         self.use_past = use_past
+        self.validate = validate
         self.share_weights = share_weights
         self.opset = opset
+        self.optimize = optimize
         self.only_ort = only_ort
 
     def _load_and_prepare(self, config: Dict[str, Any]) -> torch.nn.Module:
@@ -65,24 +74,24 @@ class TransformerFlexOnnxMemory(ModelEvaluator):
 
         # There is a bug for Python < 3.10 when using TemporaryFile with Windows,
         # thus, we opted to manually save and remove the temporary file
-        tmp_path = "tmp.onnx"
+        TMP_FOLDER.mkdir(parents=True, exist_ok=True)
+        onnx_path = TMP_FOLDER / "model.onnx"
 
         onnx_config = export_to_onnx(
             model,
-            tmp_path,
+            onnx_path.as_posix(),
             task="causal-lm",
             use_past=self.use_past,
+            validate=self.validate,
             share_weights=self.share_weights,
             opset=self.opset,
         )
-        opt_tmp_path = optimize_onnx(tmp_path, onnx_config, opt_level=0, only_ort=self.only_ort)
 
-        memory = os.path.getsize(opt_tmp_path) / (1024**2)
+        if self.optimize:
+            onnx_path = optimize_onnx(onnx_path.as_posix(), onnx_config, opt_level=0, only_ort=self.only_ort)
 
-        try:
-            os.remove(tmp_path)
-            os.remove(opt_tmp_path)
-        except FileNotFoundError:
-            pass
+        memory = pathlib.Path(onnx_path).stat().st_size / (1024**2)
+
+        shutil.rmtree(TMP_FOLDER)
 
         return memory

--- a/archai/onnx/export.py
+++ b/archai/onnx/export.py
@@ -114,6 +114,7 @@ def export_to_onnx(
     output_model_path: str,
     task: Optional[str] = "causal-lm",
     use_past: Optional[bool] = True,
+    validate: Optional[bool] = True,
     share_weights: Optional[bool] = True,
     opset: Optional[int] = 11,
     atol: Optional[float] = 1e-4,
@@ -125,6 +126,7 @@ def export_to_onnx(
         output_model_path: Path to save the exported ONNX model.
         task: Task identifier to use proper inputs/outputs.
         use_past: Whether to include past key/values in the model.
+        validate: Whether to validate the exported model.
         share_weights: Whether to share the embedding and softmax weights.
         opset: Set of operations to use with ONNX.
         atol: Tolerance between input and exported model.
@@ -162,7 +164,9 @@ def export_to_onnx(
         opset_version=opset,
         do_constant_folding=True,
     )
-    validate_onnx_outputs(onnx_config, model, output_model_path, atol)
+
+    if validate:
+        validate_onnx_outputs(onnx_config, model, output_model_path, atol)
 
     if share_weights:
         weight_sharing(output_model_path, model_type)

--- a/archai/onnx/onnx_loader.py
+++ b/archai/onnx/onnx_loader.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 from os import environ
+from typing import List, Optional
 
 from onnxruntime import GraphOptimizationLevel, InferenceSession, SessionOptions
 
@@ -10,7 +11,7 @@ from archai.common.ordered_dict_logger import OrderedDictLogger
 logger = OrderedDictLogger(source=__name__)
 
 
-def load_from_onnx(onnx_model_path: str) -> InferenceSession:
+def load_from_onnx(onnx_model_path: str, providers: Optional[List[str]] = None) -> InferenceSession:
     """Load an ONNX-based model from file.
 
     This function loads an ONNX-based model from the specified file path and
@@ -18,6 +19,7 @@ def load_from_onnx(onnx_model_path: str) -> InferenceSession:
 
     Args:
         onnx_model_path: Path to the ONNX model file.
+        providers: List of providers to use for inference.
 
     Returns:
         ONNX inference session.
@@ -35,7 +37,7 @@ def load_from_onnx(onnx_model_path: str) -> InferenceSession:
     options.intra_op_num_threads = OMP_NUM_THREADS
     options.graph_optimization_level = GraphOptimizationLevel.ORT_ENABLE_ALL
 
-    session = InferenceSession(onnx_model_path, sess_options=options)
+    session = InferenceSession(onnx_model_path, sess_options=options, providers=providers)
     session.disable_fallback()
 
     return session

--- a/archai/onnx/onnx_loader.py
+++ b/archai/onnx/onnx_loader.py
@@ -37,6 +37,8 @@ def load_from_onnx(onnx_model_path: str, providers: Optional[List[str]] = None) 
     options.intra_op_num_threads = OMP_NUM_THREADS
     options.graph_optimization_level = GraphOptimizationLevel.ORT_ENABLE_ALL
 
+    providers = providers or ["CPUExecutionProvider"]
+
     session = InferenceSession(onnx_model_path, sess_options=options, providers=providers)
     session.disable_fallback()
 

--- a/tasks/text_generation/search.py
+++ b/tasks/text_generation/search.py
@@ -107,13 +107,13 @@ if __name__ == "__main__":
     )
     search_objectives.add_objective(
         "onnx_latency",
-        TransformerFlexOnnxLatency(space),
+        TransformerFlexOnnxLatency(space, providers=["CPUExecutionProvider"], seq_len=1024, n_trials=5, use_past=False),
         higher_is_better=False,
         compute_intensive=False,
     )
     search_objectives.add_objective(
         "onnx_memory",
-        TransformerFlexOnnxMemory(space),
+        TransformerFlexOnnxMemory(space, use_past=False),
         higher_is_better=False,
         compute_intensive=False,
     )

--- a/tasks/text_generation/search.py
+++ b/tasks/text_generation/search.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
     )
     search_objectives.add_objective(
         "onnx_latency",
-        TransformerFlexOnnxLatency(space, providers=["CPUExecutionProvider"], seq_len=1024, n_trials=5, use_past=False),
+        TransformerFlexOnnxLatency(space, seq_len=1024, n_trials=5, use_past=False),
         higher_is_better=False,
         compute_intensive=False,
     )


### PR DESCRIPTION
# Pull Request Template

## Description

- Adds a `validate` option to choose whether validation should be performed during ONNX exports;
- Adds support on ONNX-based evaluators to use `validate` and `optimize` (whether optimization should be performed);
- Adds support for custom providers when loading an ONNX model (allows for GPU-based measurement using the `CUDAExecutionProvider`).

## Changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

**Configuration**:
* Archai version: 1.0.0
* Environment: Python 3.7/3.8
* OS: Windows 11

## Final checks:

- [X] Follows guidelines of project
- [X] Self-review of code
- [X] Commented code in hard-to-understand areas
- [X] Corresponding changes to the documentation
- [X] Changes generate no new warnings
- [X] Dependent changes have already been merged
- [X] Checked code correction any misspellings