### PR TITLE
Fixes memory overflow when running searches with `EvolutionPareto`

### DIFF
--- a/archai/discrete_search/algos/bananas.py
+++ b/archai/discrete_search/algos/bananas.py
@@ -47,7 +47,7 @@ class MoBananasSearch(Searcher):
         num_parents: Optional[int] = 10,
         mutations_per_parent: Optional[int] = 5,
         num_candidates: Optional[int] = 10,
-        clear_evaluated_models: bool = False,
+        clear_evaluated_models: bool = True,
         save_pareto_weights: bool = False,
         seed: Optional[int] = 1,
     ) -> None:
@@ -67,7 +67,7 @@ class MoBananasSearch(Searcher):
             mutations_per_parent: Number of mutations to apply to each parent.
             num_candidates: Number of selected models to add to evaluate in the next iteration.
             clear_evaluated_models: Optimizes memory usage by clearing the architecture
-                of `ArchaiModel` after each iteration.
+                of `ArchaiModel` after each iteration. Defaults to True
             save_pareto_model_weights: If `False`, saves the weights of the pareto models.
             seed: Random seed.
 

--- a/archai/discrete_search/algos/bananas.py
+++ b/archai/discrete_search/algos/bananas.py
@@ -47,6 +47,8 @@ class MoBananasSearch(Searcher):
         num_parents: Optional[int] = 10,
         mutations_per_parent: Optional[int] = 5,
         num_candidates: Optional[int] = 10,
+        clear_evaluated_models: bool = False,
+        save_pareto_weights: bool = False,
         seed: Optional[int] = 1,
     ) -> None:
         """Initialize the multi-objective BANANAS.
@@ -64,6 +66,9 @@ class MoBananasSearch(Searcher):
             num_parents: Number of parents to select for each iteration.
             mutations_per_parent: Number of mutations to apply to each parent.
             num_candidates: Number of selected models to add to evaluate in the next iteration.
+            clear_evaluated_models: Optimizes memory usage by clearing the architecture
+                of `ArchaiModel` after each iteration.
+            save_pareto_model_weights: If `False`, saves the weights of the pareto models.
             seed: Random seed.
 
         """
@@ -94,11 +99,16 @@ class MoBananasSearch(Searcher):
         self.num_candidates = num_candidates
 
         # Utils
+        self.clear_evaluated_models = clear_evaluated_models
+        self.save_pareto_weights = save_pareto_weights
         self.seen_archs = set()
         self.seed = seed
         self.rng = np.random.RandomState(self.seed)
         self.surrogate_dataset = []
         self.search_state = SearchResults(search_space, search_objectives)
+
+        if self.save_pareto_weights:
+            raise NotImplementedError
 
     def get_surrogate_iter_dataset(self, all_pop: List[ArchaiModel]) -> Tuple[np.ndarray, np.ndarray]:
         """Get the surrogate dataset for the current iteration.
@@ -258,6 +268,11 @@ class MoBananasSearch(Searcher):
                 for c in ["mean", "var"]
             }
             self.search_state.add_iteration_results(unseen_pop, iter_results, extra_model_data)
+
+            # Clears models from memory if needed
+            if self.clear_evaluated_models:
+                for m in unseen_pop:
+                    m.clear()
 
             # Updates surrogate
             logger.info("Updating surrogate model ...")

--- a/archai/discrete_search/algos/evolution_pareto.py
+++ b/archai/discrete_search/algos/evolution_pareto.py
@@ -43,7 +43,7 @@ class EvolutionParetoSearch(Searcher):
         max_unseen_population: Optional[int] = 100,
         mutations_per_parent: Optional[int] = 1,
         num_crossovers: Optional[int] = 5,
-        clear_evaluated_models: bool = False,
+        clear_evaluated_models: bool = True,
         save_pareto_model_weights: bool = True,
         seed: Optional[int] = 1,
     ):
@@ -63,8 +63,8 @@ class EvolutionParetoSearch(Searcher):
             mutations_per_parent: Number of distinct mutations generated for each Pareto frontier member.
             num_crossovers: Total number of crossovers generated per iteration.
             clear_evaluated_models: Optimizes memory usage by clearing the architecture
-                of `ArchaiModel` after each iteration.
-            save_pareto_model_weights: If `True`, saves the weights of the pareto models.
+                of `ArchaiModel` after each iteration. Defaults to True
+            save_pareto_model_weights: If `True`, saves the weights of the pareto models. Defaults to True
             seed: Random seed.
 
         """

--- a/archai/discrete_search/algos/evolution_pareto.py
+++ b/archai/discrete_search/algos/evolution_pareto.py
@@ -43,6 +43,7 @@ class EvolutionParetoSearch(Searcher):
         max_unseen_population: Optional[int] = 100,
         mutations_per_parent: Optional[int] = 1,
         num_crossovers: Optional[int] = 5,
+        optimize_memory_usage: Optional[bool] = False,
         seed: Optional[int] = 1,
     ):
         """Initialize the evolutionary search algorithm.
@@ -60,6 +61,8 @@ class EvolutionParetoSearch(Searcher):
             max_unseen_population: Maximum number of unseen models to evaluate in each iteration.
             mutations_per_parent: Number of distinct mutations generated for each Pareto frontier member.
             num_crossovers: Total number of crossovers generated per iteration.
+            optimize_memory_usage: Optimizes memory usage by clearing the architecture
+                of `ArchaiModel` after each iteration.
             seed: Random seed.
 
         """
@@ -83,6 +86,7 @@ class EvolutionParetoSearch(Searcher):
         self.max_unseen_population = max_unseen_population
         self.mutations_per_parent = mutations_per_parent
         self.num_crossovers = num_crossovers
+        self.optimize_memory_usage = optimize_memory_usage
 
         # Utils
         self.search_state = SearchResults(search_space, self.so)
@@ -250,6 +254,11 @@ class EvolutionParetoSearch(Searcher):
 
             # Records evaluated archs to avoid computing the same architecture twice
             self.seen_archs.update([m.archid for m in unseen_pop])
+
+            # Optimizes memory usage by clearing architectures from memory
+            if self.optimize_memory_usage:
+                logger.info("Optimzing memory usage ...")
+                [model.clear() for model in unseen_pop]
 
             # update the pareto frontier
             logger.info("Updating Pareto frontier ...")

--- a/archai/discrete_search/algos/evolution_pareto.py
+++ b/archai/discrete_search/algos/evolution_pareto.py
@@ -267,7 +267,7 @@ class EvolutionParetoSearch(Searcher):
             self.search_state.save_search_state(str(self.output_dir / f"search_state_{self.iter_num}.csv"))
             self.search_state.save_pareto_frontier_models(
                 str(self.output_dir / f"pareto_models_iter_{self.iter_num}"),
-                save_weights=self.save_pareto_weights
+                save_weights=self.save_pareto_model_weights
             )
             self.search_state.save_all_2d_pareto_evolution_plots(str(self.output_dir))
 

--- a/archai/discrete_search/algos/evolution_pareto.py
+++ b/archai/discrete_search/algos/evolution_pareto.py
@@ -43,7 +43,7 @@ class EvolutionParetoSearch(Searcher):
         max_unseen_population: Optional[int] = 100,
         mutations_per_parent: Optional[int] = 1,
         num_crossovers: Optional[int] = 5,
-        optimize_memory_usage: Optional[bool] = False,
+        clear_evaluated_models: Optional[bool] = False,
         seed: Optional[int] = 1,
     ):
         """Initialize the evolutionary search algorithm.
@@ -61,7 +61,7 @@ class EvolutionParetoSearch(Searcher):
             max_unseen_population: Maximum number of unseen models to evaluate in each iteration.
             mutations_per_parent: Number of distinct mutations generated for each Pareto frontier member.
             num_crossovers: Total number of crossovers generated per iteration.
-            optimize_memory_usage: Optimizes memory usage by clearing the architecture
+            clear_evaluated_models: Optimizes memory usage by clearing the architecture
                 of `ArchaiModel` after each iteration.
             seed: Random seed.
 
@@ -86,7 +86,7 @@ class EvolutionParetoSearch(Searcher):
         self.max_unseen_population = max_unseen_population
         self.mutations_per_parent = mutations_per_parent
         self.num_crossovers = num_crossovers
-        self.optimize_memory_usage = optimize_memory_usage
+        self.clear_evaluated_models = clear_evaluated_models
 
         # Utils
         self.search_state = SearchResults(search_space, self.so)
@@ -256,7 +256,7 @@ class EvolutionParetoSearch(Searcher):
             self.seen_archs.update([m.archid for m in unseen_pop])
 
             # Optimizes memory usage by clearing architectures from memory
-            if self.optimize_memory_usage:
+            if self.clear_evaluated_models:
                 logger.info("Optimzing memory usage ...")
                 [model.clear() for model in unseen_pop]
 

--- a/archai/discrete_search/algos/local_search.py
+++ b/archai/discrete_search/algos/local_search.py
@@ -30,6 +30,8 @@ class LocalSearch(Searcher):
         init_num_models: Optional[int] = 10,
         initial_population_paths: Optional[List[str]] = None,
         mutations_per_parent: Optional[int] = 1,
+        clear_evaluated_models: Optional[bool] = False,
+        save_pareto_model_weights: bool = True,
         seed: Optional[int] = 1,
     ):
         """Local search algorithm. In each iteration, the algorithm generates a new population by
@@ -45,6 +47,9 @@ class LocalSearch(Searcher):
             initial_population_paths (Optional[List[str]], optional): Paths to initial population.
                 If None, then `init_num_models` random models are used. Defaults to None.
             mutations_per_parent (int, optional): Number of mutations per parent. Defaults to 1.
+            clear_evaluated_models (bool, optional): Optimizes memory usage by clearing the architecture
+                of `ArchaiModel` after each iteration. Defaults to False.
+            save_pareto_model_weights: If `True`, saves the weights of the pareto models.
             seed (int, optional): Random seed. Defaults to 1.
         """
         assert isinstance(
@@ -65,6 +70,8 @@ class LocalSearch(Searcher):
         self.mutations_per_parent = mutations_per_parent
 
         # Utils
+        self.clear_evaluated_models = clear_evaluated_models
+        self.save_pareto_model_weights = save_pareto_model_weights
         self.search_state = SearchResults(search_space, self.so)
         self.seed = seed
         self.rng = random.Random(seed)
@@ -176,8 +183,17 @@ class LocalSearch(Searcher):
 
             # Saves search iteration results
             self.search_state.save_search_state(str(self.output_dir / f"search_state_{self.iter_num}.csv"))
-            self.search_state.save_pareto_frontier_models(str(self.output_dir / f"pareto_models_iter_{self.iter_num}"))
+            self.search_state.save_pareto_frontier_models(
+                str(self.output_dir / f"pareto_models_iter_{self.iter_num}"), 
+                save_weights=self.save_pareto_model_weights
+            )
             self.search_state.save_all_2d_pareto_evolution_plots(str(self.output_dir))
+
+            # Clears models from memory if needed
+            if self.clear_evaluated_models:
+                logger.info("Optimzing memory usage ...")
+                [model.clear() for model in unseen_pop]
+
 
             # mutate random 'k' subsets of the parents
             # while ensuring the mutations fall within

--- a/archai/discrete_search/algos/local_search.py
+++ b/archai/discrete_search/algos/local_search.py
@@ -30,7 +30,7 @@ class LocalSearch(Searcher):
         init_num_models: Optional[int] = 10,
         initial_population_paths: Optional[List[str]] = None,
         mutations_per_parent: Optional[int] = 1,
-        clear_evaluated_models: Optional[bool] = False,
+        clear_evaluated_models: bool = True,
         save_pareto_model_weights: bool = True,
         seed: Optional[int] = 1,
     ):
@@ -48,7 +48,7 @@ class LocalSearch(Searcher):
                 If None, then `init_num_models` random models are used. Defaults to None.
             mutations_per_parent (int, optional): Number of mutations per parent. Defaults to 1.
             clear_evaluated_models (bool, optional): Optimizes memory usage by clearing the architecture
-                of `ArchaiModel` after each iteration. Defaults to False.
+                of `ArchaiModel` after each iteration. Defaults to True.
             save_pareto_model_weights: If `True`, saves the weights of the pareto models.
             seed (int, optional): Random seed. Defaults to 1.
         """

--- a/archai/discrete_search/algos/random_search.py
+++ b/archai/discrete_search/algos/random_search.py
@@ -34,7 +34,7 @@ class RandomSearch(Searcher):
         output_dir: str,
         num_iters: Optional[int] = 10,
         samples_per_iter: Optional[int] = 10,
-        clear_evaluated_models: Optional[bool] = False,
+        clear_evaluated_models: Optional[bool] = True,
         save_pareto_model_weights: bool = True,
         seed: Optional[int] = 1,
     ):
@@ -48,8 +48,8 @@ class RandomSearch(Searcher):
             num_iters: Number of iterations.
             samples_per_iter: Number of samples per iteration.
             clear_evaluated_models (bool, optional): Optimizes memory usage by clearing the architecture
-                of `ArchaiModel` after each iteration. Defaults to False.
-            save_pareto_model_weights: If `True`, saves the weights of the pareto models.
+                of `ArchaiModel` after each iteration. Defaults to True.
+            save_pareto_model_weights: If `True`, saves the weights of the pareto models. Defaults to True.
             seed: Random seed.
         """
 

--- a/archai/discrete_search/algos/regularized_evolution.py
+++ b/archai/discrete_search/algos/regularized_evolution.py
@@ -41,6 +41,8 @@ class RegularizedEvolutionSearch(Searcher):
         initial_population_paths: Optional[List[str]] = None,
         pareto_sample_size: Optional[int] = 40,
         history_size: Optional[int] = 100,
+        clear_evaluated_models: Optional[bool] = False,
+        save_pareto_model_weights: bool = True,
         seed: Optional[int] = 1,
     ) -> None:
         """Initialize the Regularized Evolution.
@@ -55,6 +57,9 @@ class RegularizedEvolutionSearch(Searcher):
             initial_population_paths: Paths to initial population models.
             pareto_sample_size: Number of models to sample from the pareto frontier.
             history_size: Number of models to keep in the history.
+            clear_evaluated_models (bool, optional): Optimizes memory usage by clearing the architecture
+                of `ArchaiModel` after each iteration. Defaults to False.
+            save_pareto_model_weights: If `True`, saves the weights of the pareto models.
             seed: Random seed.
 
         """
@@ -76,6 +81,7 @@ class RegularizedEvolutionSearch(Searcher):
         self.initial_population_paths = initial_population_paths
         self.pareto_sample_size = pareto_sample_size
         self.history_size = history_size
+        self.clear_evaluated_models = clear_evaluated_models
 
         # Utils
         self.search_state = SearchResults(search_space, self.so)
@@ -183,8 +189,16 @@ class RegularizedEvolutionSearch(Searcher):
 
             # Saves search iteration results
             self.search_state.save_search_state(str(self.output_dir / f"search_state_{self.iter_num}.csv"))
-            self.search_state.save_pareto_frontier_models(str(self.output_dir / f"pareto_models_iter_{self.iter_num}"))
+            self.search_state.save_pareto_frontier_models(
+                str(self.output_dir / f"pareto_models_iter_{self.iter_num}"),
+                save_weights=self.save_pareto_model_weights
+            )
             self.search_state.save_all_2d_pareto_evolution_plots(str(self.output_dir))
+
+            # Clears models from memory if needed
+            if self.clear_evaluated_models:
+                logger.info("Optimzing memory usage ...")
+                [model.clear() for model in iter_members]
 
             # Samples subset of models from the history buffer
             history_indices = list(range(max(0, len(self.all_pop) - self.history_size), len(self.all_pop)))

--- a/archai/discrete_search/algos/regularized_evolution.py
+++ b/archai/discrete_search/algos/regularized_evolution.py
@@ -81,9 +81,10 @@ class RegularizedEvolutionSearch(Searcher):
         self.initial_population_paths = initial_population_paths
         self.pareto_sample_size = pareto_sample_size
         self.history_size = history_size
-        self.clear_evaluated_models = clear_evaluated_models
 
         # Utils
+        self.clear_evaluated_models = clear_evaluated_models
+        self.save_pareto_model_weights = save_pareto_model_weights        
         self.search_state = SearchResults(search_space, self.so)
         self.seed = seed
         self.rng = random.Random(seed)

--- a/archai/discrete_search/algos/regularized_evolution.py
+++ b/archai/discrete_search/algos/regularized_evolution.py
@@ -41,7 +41,7 @@ class RegularizedEvolutionSearch(Searcher):
         initial_population_paths: Optional[List[str]] = None,
         pareto_sample_size: Optional[int] = 40,
         history_size: Optional[int] = 100,
-        clear_evaluated_models: Optional[bool] = False,
+        clear_evaluated_models: Optional[bool] = True,
         save_pareto_model_weights: bool = True,
         seed: Optional[int] = 1,
     ) -> None:
@@ -58,7 +58,7 @@ class RegularizedEvolutionSearch(Searcher):
             pareto_sample_size: Number of models to sample from the pareto frontier.
             history_size: Number of models to keep in the history.
             clear_evaluated_models (bool, optional): Optimizes memory usage by clearing the architecture
-                of `ArchaiModel` after each iteration. Defaults to False.
+                of `ArchaiModel` after each iteration. Defaults to True.
             save_pareto_model_weights: If `True`, saves the weights of the pareto models.
             seed: Random seed.
 

--- a/archai/discrete_search/api/archai_model.py
+++ b/archai/discrete_search/api/archai_model.py
@@ -28,3 +28,13 @@ class ArchaiModel:
 
     def __str__(self) -> str:
         return repr(self)
+
+    def clear(self) -> None:
+        """Clear architecture from memory.
+
+        Sometimes, after evaluating an `ArchaiModel`, there is no need to keep its
+        architecture instantiated, which optimizes memory usage.
+
+        """
+
+        self.arch = None

--- a/archai/discrete_search/api/search_results.py
+++ b/archai/discrete_search/api/search_results.py
@@ -168,16 +168,15 @@ class SearchResults:
             save_weights: If `True`, saves the model weights. Otherwise, only saves the architecture.
 
         """
-
-        if save_weights:
-            raise NotImplementedError
-
         dir_path = Path(directory)
         dir_path.mkdir(exist_ok=True, parents=True)
 
         pareto_frontier = self.get_pareto_frontier()
         for model in pareto_frontier["models"]:
             self.search_space.save_arch(model, str(dir_path / f"{model.archid}"))
+
+            if save_weights:
+                self.search_space.save_model_weights(model, str(dir_path / f"{model.archid}_weights.pt"))
 
     def plot_2d_pareto_evolution(
         self, objective_names: Tuple[str, str], figsize: Optional[Tuple[int, int]] = (10, 5)

--- a/archai/discrete_search/search_spaces/nlp/transformer_flex/search_space.py
+++ b/archai/discrete_search/search_spaces/nlp/transformer_flex/search_space.py
@@ -101,7 +101,7 @@ class TransformerFlexSearchSpace(EvolutionarySearchSpace, BayesOptSearchSpace):
         vocab_size: Optional[int] = 10_000,
         max_sequence_length: Optional[int] = 1024,
         att_dropout_rate: Optional[float] = 0.0,
-        disable_init_weights: Optional[bool] = False,
+        disable_weights_init: Optional[bool] = False,
         random_seed: Optional[int] = 1,
     ) -> None:
         """Initialize search space.
@@ -119,7 +119,7 @@ class TransformerFlexSearchSpace(EvolutionarySearchSpace, BayesOptSearchSpace):
             vocab_size: Size of the vocabulary.
             max_sequence_length: Maximum sequence length.
             att_dropout_rate: Dropout rate for attention.
-            disable_init_weights: Whether to disable initialization of weights.
+            disable_weights_init: Whether to disable weights initialization.
             random_seed: Random seed for reproducibility.
 
         """
@@ -145,7 +145,7 @@ class TransformerFlexSearchSpace(EvolutionarySearchSpace, BayesOptSearchSpace):
         self.vocab_size = vocab_size
         self.max_sequence_length = max_sequence_length
         self.att_dropout_rate = att_dropout_rate
-        self.disable_init_weights = disable_init_weights
+        self.disable_weights_init = disable_weights_init
 
     def _load_model_from_config(self, model_config: Dict[str, Any]) -> torch.nn.Module:
         param_map = self._DEFAULT_MODELS[self.arch_type]
@@ -153,7 +153,7 @@ class TransformerFlexSearchSpace(EvolutionarySearchSpace, BayesOptSearchSpace):
 
         config = AutoConfig.for_model(self.arch_type, **mapped_config)
 
-        if self.disable_init_weights:
+        if self.disable_weights_init:
             with no_init_weights():
                 return AutoModelForCausalLM.from_config(config)
 

--- a/tasks/text_generation/search.py
+++ b/tasks/text_generation/search.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
         max_unseen_population=args.max_unseen_population,
         mutations_per_parent=args.mutations_per_parent,
         num_crossovers=args.num_crossovers,
-        optimize_memory_usage=True,
+        clear_evaluated_models=True,
         seed=args.seed,
     )
     algo.search()

--- a/tasks/text_generation/search.py
+++ b/tasks/text_generation/search.py
@@ -135,6 +135,7 @@ if __name__ == "__main__":
         mutations_per_parent=args.mutations_per_parent,
         num_crossovers=args.num_crossovers,
         clear_evaluated_models=True,
+        save_pareto_model_weights=False,
         seed=args.seed,
     )
     algo.search()

--- a/tasks/text_generation/search.py
+++ b/tasks/text_generation/search.py
@@ -95,7 +95,12 @@ def parse_args() -> argparse.Namespace:
 if __name__ == "__main__":
     args = parse_args()
 
-    space = TransformerFlexSearchSpace(args.model_type, vocab_size=50257, max_sequence_length=1024)
+    space = TransformerFlexSearchSpace(
+        args.model_type,
+        vocab_size=50257,
+        max_sequence_length=1024,
+        disable_weights_init=True,
+    )
 
     search_objectives = SearchObjectives()
     search_objectives.add_objective(
@@ -129,6 +134,7 @@ if __name__ == "__main__":
         max_unseen_population=args.max_unseen_population,
         mutations_per_parent=args.mutations_per_parent,
         num_crossovers=args.num_crossovers,
+        optimize_memory_usage=True,
         seed=args.seed,
     )
     algo.search()


### PR DESCRIPTION
# Pull Request Template

## Description

- Adds a `disable_weights_init` boolean disable weights initialization in `TransformerFlexSearchSpace`.
- Adds a `clear()` method to `ArchaiModel` that allows clearing loaded architectures from memory.
- Adds a `optimize_memory_usage` boolean to `EvolutionPareto` to clear architectures and optimize memory usage.

## Changes

- [X] New feature (non-breaking change which adds functionality)

**Configuration**:
* Archai version: 1.0.0
* Environment: Python 3.7
* OS: Windows 11

## Final checks:

- [X] Follows guidelines of project
- [X] Self-review of code
- [X] Commented code in hard-to-understand areas
- [X] Corresponding changes to the documentation
- [X] Changes generate no new warnings
- [X] Dependent changes have already been merged
- [X] Checked code correction any misspellings