### PR TITLE
feat(config): add `default` parameter for `ArchConfig.pick` method

### DIFF
--- a/archai/discrete_search/search_spaces/config/arch_config.py
+++ b/archai/discrete_search/search_spaces/config/arch_config.py
@@ -64,6 +64,9 @@ class ArchConfig:
         cls_name = self.__class__.__name__
         return f"{cls_name}({json.dumps(self, cls=ArchConfigJsonEncoder, indent=4)})"
 
+    def __in__(self, param_name: str) -> bool:
+        return param_name in self.nodes
+
     def get_used_params(self) -> Dict[str, Union[Dict, bool]]:
         """Get the parameter usage tree.
 

--- a/archai/discrete_search/search_spaces/config/arch_config.py
+++ b/archai/discrete_search/search_spaces/config/arch_config.py
@@ -84,11 +84,13 @@ class ArchConfig:
 
         return used_params
 
-    def pick(self, param_name: str, record_usage: Optional[bool] = True) -> Any:
+    def pick(self, param_name: str, default: Optional[Any] = None, record_usage: Optional[bool] = True) -> Any:
         """Pick an architecture parameter, possibly recording its usage.
 
         Args:
             param_name: Architecture parameter name
+            default: Default value to return if parameter is not found. If `None`, an
+                exception is raised.
             record_usage: If this parameter should be recorded as 'used' in
                 `ArchConfig._used_params`.
 
@@ -96,8 +98,15 @@ class ArchConfig:
             Parameter value.
 
         """
-
-        param_value = self.nodes[param_name]
+        if param_name in self.nodes:
+            param_value = self.nodes[param_name]
+        else:
+            if default is None:
+                raise ValueError(
+                    f"Architecture parameter {param_name} not found in config and "
+                    f"no default value provided. Available parameters are: {self.nodes.keys()}"
+                )
+            param_value = default
 
         if record_usage:
             self._used_params.add(param_name)


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a list of changes, relevant information, context and new dependencies.

* Adds new optional parameter `default` for `ArchConfig.pick` method to select a value in case the chosen `param_name` does not exist.
* Syntax sugar for checking if a param is set inside an `ArchConfig` object (implements `ArchConfig.__in__(param_name)`)

Fixes: # (issue)

## Changes

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to not work as expected)
- [ ] Documentation update


## Final checks:

- [ ] Follows guidelines of project
- [ ] Self-review of code
- [ ] Commented code in hard-to-understand areas
- [ ] Corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Dependent changes have already been merged
- [ ] Checked code correction any misspellings