### PR TITLE
Fix unit tests so they work on Windows.

### DIFF
--- a/.github/workflows/lint-run-unit-tests.yaml
+++ b/.github/workflows/lint-run-unit-tests.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Installs the requirements
         shell: bash -l {0}
         run: |
-          python -m pip install --user -e .[dev]
+          python3 -m pip install --user -e .[dev]
       - name: Finds syntax errors and undefined names
         shell: bash -l {0}
         run: |
@@ -49,4 +49,4 @@ jobs:
       - name: Runs unit tests
         shell: bash -l {0}
         run: |
-          pytest tests
+          python3 -m pytest tests

--- a/.github/workflows/lint-run-unit-tests.yaml
+++ b/.github/workflows/lint-run-unit-tests.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:        
-        platform: [ windows-latest, ubuntu-latest, macos-latest ]
+        platform: [ windows-latest, ubuntu-latest ]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/lint-run-unit-tests.yaml
+++ b/.github/workflows/lint-run-unit-tests.yaml
@@ -17,11 +17,12 @@ on:
 jobs:
   lint-run-tests:
     name: Lints with `flake8` and run unit tests with `pytest`
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
+      matrix:        
+        platform: [ windows-latest, ubuntu-latest, macos-latest ]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+    runs-on: ${{ matrix.platform }}
     steps:
       - name: Pulls the repository
         uses: actions/checkout@v3
@@ -34,9 +35,7 @@ jobs:
       - name: Installs the requirements
         shell: bash -l {0}
         run: |
-          sudo apt install -y graphviz
           python -m pip install --user -e .[dev]
-          python -m pip install graphviz
       - name: Finds syntax errors and undefined names
         shell: bash -l {0}
         run: |

--- a/archai/common/file_utils.py
+++ b/archai/common/file_utils.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-
+from __future__ import annotations
 import os
 import pathlib
 import re

--- a/archai/datasets/nlp/fast_hf_dataset_provider.py
+++ b/archai/datasets/nlp/fast_hf_dataset_provider.py
@@ -119,6 +119,13 @@ class FastHfDatasetProvider(DatasetProvider):
         )
 
         return encoded_dataset_dict
+    
+    @staticmethod
+    def _close_mem_maps(processed_dataset_dict: DatasetDict) -> None:
+        for key in processed_dataset_dict:
+            dataset = processed_dataset_dict[key]
+            if isinstance(dataset, np.memmap) and dataset._mmap is not None:
+                dataset._mmap.close()
 
     @staticmethod
     def _process_dataset_to_memory(
@@ -241,6 +248,8 @@ class FastHfDatasetProvider(DatasetProvider):
             processed_dataset_dict, tokenizer, cache_dir, use_shared_memory
         )
 
+        FastHfDatasetProvider._close_mem_maps(processed_dataset_dict)
+
         with open(cache_dir / "config.json", "w") as f:
             json.dump(
                 {
@@ -344,6 +353,8 @@ class FastHfDatasetProvider(DatasetProvider):
         cache_files = FastHfDatasetProvider._save_dataset(
             processed_dataset_dict, tokenizer, cache_dir, use_shared_memory
         )
+
+        FastHfDatasetProvider._close_mem_maps(processed_dataset_dict)
 
         with open(cache_dir / "config.json", "w") as f:
             json.dump(

--- a/archai/datasets/nlp/fast_hf_dataset_provider.py
+++ b/archai/datasets/nlp/fast_hf_dataset_provider.py
@@ -119,7 +119,7 @@ class FastHfDatasetProvider(DatasetProvider):
         )
 
         return encoded_dataset_dict
-    
+
     @staticmethod
     def _close_mem_maps(processed_dataset_dict: DatasetDict) -> None:
         for key in processed_dataset_dict:

--- a/archai/datasets/nlp/fast_hf_dataset_provider.py
+++ b/archai/datasets/nlp/fast_hf_dataset_provider.py
@@ -46,6 +46,7 @@ class FastHfDatasetProvider(DatasetProvider):
         validation_file: str,
         test_file: str,
         tokenizer: Optional[AutoTokenizer] = None,
+        mmap_mode: str = 'r',
     ) -> None:
         """Initialize Fast Hugging Face-based dataset provider.
 
@@ -63,6 +64,7 @@ class FastHfDatasetProvider(DatasetProvider):
         self.validation_file = validation_file
         self.test_file = test_file
         self.tokenizer = tokenizer
+        self.mmap_mode = mmap_mode
 
     @staticmethod
     def _create_splits(dataset_dict: DatasetDict, validation_split: float, seed: int) -> DatasetDict:
@@ -176,6 +178,7 @@ class FastHfDatasetProvider(DatasetProvider):
         use_eos_token: Optional[bool] = True,
         use_shared_memory: Optional[bool] = True,
         cache_dir: Optional[str] = "cache",
+        mmap_mode: str = 'r'
     ) -> FastHfDatasetProvider:
         """Load a dataset provider by loading and encoding data from disk.
 
@@ -255,7 +258,7 @@ class FastHfDatasetProvider(DatasetProvider):
                 f,
             )
 
-        return FastHfDatasetProvider(**cache_files, tokenizer=tokenizer)
+        return FastHfDatasetProvider(**cache_files, tokenizer=tokenizer, mmap_mode=mmap_mode)
 
     @classmethod
     def from_hub(
@@ -275,6 +278,7 @@ class FastHfDatasetProvider(DatasetProvider):
         use_eos_token: Optional[bool] = True,
         use_shared_memory: Optional[bool] = True,
         cache_dir: Optional[str] = "cache",
+        mmap_mode: str = 'r'
     ) -> FastHfDatasetProvider:
         """Load a dataset provider by downloading and encoding data from Hugging Face Hub.
 
@@ -361,10 +365,10 @@ class FastHfDatasetProvider(DatasetProvider):
                 f,
             )
 
-        return FastHfDatasetProvider(**cache_files, tokenizer=tokenizer)
+        return FastHfDatasetProvider(**cache_files, tokenizer=tokenizer, mmap_mode=mmap_mode)
 
     @classmethod
-    def from_cache(cls: FastHfDatasetProvider, cache_dir: str) -> FastHfDatasetProvider:
+    def from_cache(cls: FastHfDatasetProvider, cache_dir: str, mmap_mode='r') -> FastHfDatasetProvider:
         """Load a dataset provider from a cache directory.
 
         Args:
@@ -390,23 +394,23 @@ class FastHfDatasetProvider(DatasetProvider):
             with open(tokenizer_file, "rb") as f:
                 tokenizer = pickle.load(f)
 
-        return FastHfDatasetProvider(cache_train_file, cache_validation_file, cache_test_file, tokenizer=tokenizer)
+        return FastHfDatasetProvider(cache_train_file, cache_validation_file, cache_test_file, tokenizer=tokenizer, mmap_mode=mmap_mode)
 
     @overrides
     def get_train_dataset(self, seq_len: Optional[int] = 1) -> FastHfDataset:
-        input_ids = np.load(self.train_file, mmap_mode="r")
+        input_ids = np.load(self.train_file, mmap_mode=self.mmap_mode)
 
         return FastHfDataset(input_ids, seq_len=seq_len)
 
     @overrides
     def get_val_dataset(self, seq_len: Optional[int] = 1) -> FastHfDataset:
-        input_ids = np.load(self.validation_file, mmap_mode="r")
+        input_ids = np.load(self.validation_file, mmap_mode=self.mmap_mode)
 
         return FastHfDataset(input_ids, seq_len=seq_len)
 
     @overrides
     def get_test_dataset(self, seq_len: Optional[int] = 1) -> FastHfDataset:
-        input_ids = np.load(self.test_file, mmap_mode="r")
+        input_ids = np.load(self.test_file, mmap_mode=self.mmap_mode)
 
         return FastHfDataset(input_ids, seq_len=seq_len)
 

--- a/archai/datasets/nlp/fast_hf_dataset_provider.py
+++ b/archai/datasets/nlp/fast_hf_dataset_provider.py
@@ -276,8 +276,7 @@ class FastHfDatasetProvider(DatasetProvider):
         num_workers: Optional[int] = 1,
         use_eos_token: Optional[bool] = True,
         use_shared_memory: Optional[bool] = True,
-        cache_dir: Optional[str] = "cache",
-        mmap_mode: str = 'r'
+        cache_dir: Optional[str] = "cache"
     ) -> FastHfDatasetProvider:
         """Load a dataset provider by downloading and encoding data from Hugging Face Hub.
 
@@ -364,7 +363,7 @@ class FastHfDatasetProvider(DatasetProvider):
                 f,
             )
 
-        return FastHfDatasetProvider(**cache_files, tokenizer=tokenizer, mmap_mode=mmap_mode)
+        return FastHfDatasetProvider(**cache_files, tokenizer=tokenizer)
 
     @classmethod
     def from_cache(cls: FastHfDatasetProvider, cache_dir: str) -> FastHfDatasetProvider:

--- a/archai/datasets/nlp/fast_hf_dataset_provider_utils.py
+++ b/archai/datasets/nlp/fast_hf_dataset_provider_utils.py
@@ -11,6 +11,7 @@ import math
 import mmap
 import sys
 from typing import Any, Dict, Optional, Tuple
+from types import TracebackType
 
 import numpy as np
 import torch
@@ -42,6 +43,13 @@ class FastHfDataset(Dataset):
         # `input_ids` should not be sliced since they could be memory mapped
         self.input_ids = input_ids
         self.n_sequences = math.ceil((self.n_input_ids - 1) / self.seq_len)
+    
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> None:
+        if isinstance(self.input_ids, np.memmap) and self.input_ids._mmap is not None:
+            self.input_ids._mmap.close()
 
     def __len__(self) -> int:
         return self.n_sequences

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ dependencies = [
     "statopt",
     "tensorboard",
     "tensorwatch",
+    "tk",
     "tokenizers>=0.10.3",
     "torchvision",
     "tqdm",
@@ -101,7 +102,8 @@ extras_require["tests"] = filter_dependencies(
     "azure-identity",
     "azure-storage-blob",
     "flake8",
-    "pytest"
+    "pytest",
+    "tk",
 )
 
 extras_require["aml"] = filter_dependencies(

--- a/tests/common/test_file_utils.py
+++ b/tests/common/test_file_utils.py
@@ -4,7 +4,6 @@
 import os
 import shutil
 import tempfile
-
 import torch
 
 from archai.common.file_utils import (
@@ -16,6 +15,7 @@ from archai.common.file_utils import (
     create_file_name_identifier,
     create_file_with_string,
     get_full_path,
+    TemporaryFiles,
 )
 
 
@@ -114,3 +114,20 @@ def test_get_full_path():
     assert os.path.exists(full_path)
 
     os.rmdir(full_path)
+
+
+def test_temporary_files():
+    with TemporaryFiles() as tmp:
+        name1 = tmp.get_temp_file()
+        name2 = tmp.get_temp_file()
+        with open(name1, 'w') as f:
+            f.write("test1")
+        with open(name2, 'w') as f:
+            f.write("test2")
+        with open(name1, 'r') as f:
+            assert f.readline() == 'test1'
+        with open(name2, 'r') as f:
+            assert f.readline() == 'test2'
+
+    assert not os.path.isfile(name1)
+    assert not os.path.isfile(name2)

--- a/tests/datasets/cv/test_mnist_dataset_provider.py
+++ b/tests/datasets/cv/test_mnist_dataset_provider.py
@@ -8,7 +8,9 @@ from archai.datasets.cv.mnist_dataset_provider import MnistDatasetProvider
 
 
 def test_mnist_dataset_provider():
-    dataset_provider = MnistDatasetProvider()
+    # make sure tests can run in parallel and not clobber each other's dataroot.
+    unique_data_root = 'test_mnist_dataset_provider_dataroot'
+    dataset_provider = MnistDatasetProvider(root=unique_data_root)
 
     # Assert that we can individually load training, validation and test datasets
     train_dataset = dataset_provider.get_train_dataset()
@@ -26,4 +28,4 @@ def test_mnist_dataset_provider():
     assert isinstance(test_dataset[0][0], torch.Tensor)
     assert isinstance(test_dataset[0][1], int)
 
-    shutil.rmtree("dataroot")
+    shutil.rmtree(unique_data_root)

--- a/tests/datasets/nlp/test_fast_hf_dataset_provider.py
+++ b/tests/datasets/nlp/test_fast_hf_dataset_provider.py
@@ -12,6 +12,7 @@ def test_fast_hf_dataset_provider_from_hub():
         tokenizer_name="Salesforce/codegen-350M-mono",
         mapping_column_name=["sentence"],
         use_shared_memory=False,
+        mmap_mode=None
     )
 
     # Assert that we can individually load training, validation and test datasets
@@ -26,7 +27,7 @@ def test_fast_hf_dataset_provider_from_hub():
 
 
 def test_fast_hf_dataset_provider_from_cache():
-    dataset_provider = FastHfDatasetProvider.from_cache("cache")
+    dataset_provider = FastHfDatasetProvider.from_cache("cache", mmap_mode=None)
 
     # Assert that we can individually load training, validation and test datasets
     train_dataset = dataset_provider.get_train_dataset(seq_len=256)

--- a/tests/datasets/nlp/test_fast_hf_dataset_provider.py
+++ b/tests/datasets/nlp/test_fast_hf_dataset_provider.py
@@ -11,8 +11,7 @@ def test_fast_hf_dataset_provider_from_hub():
         dataset_config_name="sst2",
         tokenizer_name="Salesforce/codegen-350M-mono",
         mapping_column_name=["sentence"],
-        use_shared_memory=False,
-        mmap_mode=None
+        use_shared_memory=False
     )
 
     # Assert that we can individually load training, validation and test datasets
@@ -27,7 +26,7 @@ def test_fast_hf_dataset_provider_from_hub():
 
 
 def test_fast_hf_dataset_provider_from_cache():
-    dataset_provider = FastHfDatasetProvider.from_cache("cache", mmap_mode=None)
+    dataset_provider = FastHfDatasetProvider.from_cache("cache")
 
     # Assert that we can individually load training, validation and test datasets
     train_dataset = dataset_provider.get_train_dataset(seq_len=256)

--- a/tests/datasets/nlp/test_fast_hf_dataset_provider.py
+++ b/tests/datasets/nlp/test_fast_hf_dataset_provider.py
@@ -4,6 +4,7 @@
 import shutil
 from archai.datasets.nlp.fast_hf_dataset_provider import FastHfDatasetProvider
 
+TEST_CACHE_DIR='test_fast_hf_dataset_cache'
 
 def test_fast_hf_dataset_provider_from_hub():
     dataset_provider = FastHfDatasetProvider.from_hub(
@@ -11,31 +12,32 @@ def test_fast_hf_dataset_provider_from_hub():
         dataset_config_name="sst2",
         tokenizer_name="Salesforce/codegen-350M-mono",
         mapping_column_name=["sentence"],
-        use_shared_memory=False
+        use_shared_memory=False,
+        cache_dir=TEST_CACHE_DIR
     )
 
     # Assert that we can individually load training, validation and test datasets
-    train_dataset = dataset_provider.get_train_dataset(seq_len=256)
-    assert len(train_dataset) == 3514
+    with dataset_provider.get_train_dataset(seq_len=256) as train_dataset:
+        assert len(train_dataset) == 3514
 
-    val_dataset = dataset_provider.get_val_dataset(seq_len=256)
-    assert len(val_dataset) == 85
+    with dataset_provider.get_val_dataset(seq_len=256) as val_dataset:
+        assert len(val_dataset) == 85
 
-    test_dataset = dataset_provider.get_test_dataset(seq_len=256)
-    assert len(test_dataset) == 169
+    with dataset_provider.get_test_dataset(seq_len=256) as test_dataset:
+        assert len(test_dataset) == 169
 
 
 def test_fast_hf_dataset_provider_from_cache():
-    dataset_provider = FastHfDatasetProvider.from_cache("cache")
+    dataset_provider = FastHfDatasetProvider.from_cache(TEST_CACHE_DIR)
 
     # Assert that we can individually load training, validation and test datasets
-    train_dataset = dataset_provider.get_train_dataset(seq_len=256)
-    assert len(train_dataset) == 3514
+    with dataset_provider.get_train_dataset(seq_len=256) as train_dataset:
+        assert len(train_dataset) == 3514
 
-    val_dataset = dataset_provider.get_val_dataset(seq_len=256)
-    assert len(val_dataset) == 85
+    with dataset_provider.get_val_dataset(seq_len=256) as val_dataset:
+        assert len(val_dataset) == 85
 
-    test_dataset = dataset_provider.get_test_dataset(seq_len=256)
-    assert len(test_dataset) == 169
+    with dataset_provider.get_test_dataset(seq_len=256) as test_dataset:
+        assert len(test_dataset) == 169
 
-    shutil.rmtree("cache")
+    shutil.rmtree(TEST_CACHE_DIR)

--- a/tests/datasets/nlp/test_hf_dataset_provider.py
+++ b/tests/datasets/nlp/test_hf_dataset_provider.py
@@ -35,6 +35,13 @@ def test_hf_disk_dataset_provider():
     train_dataset = dataset_provider.get_train_dataset()
     assert len(train_dataset) == 67349
 
+    # The HuggingFace dataset uses a datasets.table.MemoryMappedTable and this api provides no way
+    # to explicitly close the memory mapped file here.  On windows you cannot remove a directory
+    # while a memory mapped file is still open in that directory, so we hope the python garbage
+    # collector will close it when we clear these variables.
+    train_dataset = None
+    dataset_provider = None
+
     shutil.rmtree(unique_data_root)
 
 

--- a/tests/datasets/nlp/test_hf_dataset_provider.py
+++ b/tests/datasets/nlp/test_hf_dataset_provider.py
@@ -24,13 +24,20 @@ def test_hf_hub_dataset_provider():
 
 
 def test_hf_disk_dataset_provider():
+    # ensure parallel tests do not clobber each other over the dataroot folder.
+    unique_data_root = 'test_hf_disk_dataset_provider_dataroot'
     dataset_hub_provider = HfHubDatasetProvider("glue", dataset_config_name="sst2")
     train_dataset = dataset_hub_provider.get_train_dataset()
-    train_dataset.save_to_disk("dataroot")
+    train_dataset.save_to_disk(unique_data_root)
 
     # Assert that we can load the dataset from disk
-    dataset_provider = HfDiskDatasetProvider("dataroot")
+    dataset_provider = HfDiskDatasetProvider(unique_data_root)
     train_dataset = dataset_provider.get_train_dataset()
     assert len(train_dataset) == 67349
 
-    shutil.rmtree("dataroot")
+    shutil.rmtree(unique_data_root)
+
+
+if __name__ == '__main__':
+    test_hf_hub_dataset_provider()
+    test_hf_disk_dataset_provider()

--- a/tests/datasets/nlp/test_nvidia_dataset_provider.py
+++ b/tests/datasets/nlp/test_nvidia_dataset_provider.py
@@ -8,16 +8,19 @@ from archai.datasets.nlp.nvidia_dataset_provider import NvidiaDatasetProvider
 
 
 def test_nvidia_dataset_provider():
-    os.makedirs("dataroot/olx_tmp")
-    with open("dataroot/olx_tmp/train.txt", "w") as f:
+    # make sure tests can run in parallel and not clobber each other's dataroot.
+    unique_data_root = 'test_nvidia_dataset_provider_dataroot'
+
+    os.makedirs(f"{unique_data_root}/olx_tmp")
+    with open(f"{unique_data_root}/olx_tmp/train.txt", "w") as f:
         f.write("train")
-    with open("dataroot/olx_tmp/valid.txt", "w") as f:
+    with open(f"{unique_data_root}/olx_tmp/valid.txt", "w") as f:
         f.write("valid")
-    with open("dataroot/olx_tmp/test.txt", "w") as f:
+    with open(f"{unique_data_root}/olx_tmp/test.txt", "w") as f:
         f.write("test")
 
     # Assert that we can individually load training, validation and test datasets
-    dataset_provider = NvidiaDatasetProvider("olx_tmp", dataset_dir="dataroot/olx_tmp", refresh_cache=True)
+    dataset_provider = NvidiaDatasetProvider("olx_tmp", dataset_dir=f"{unique_data_root}/olx_tmp", refresh_cache=True)
 
     train_dataset = dataset_provider.get_train_dataset()
     assert len(train_dataset) == 7
@@ -29,4 +32,4 @@ def test_nvidia_dataset_provider():
     assert len(test_dataset) == 6
 
     shutil.rmtree("cache")
-    shutil.rmtree("dataroot")
+    shutil.rmtree(unique_data_root)

--- a/tests/discrete_search/api/test_search_objectives.py
+++ b/tests/discrete_search/api/test_search_objectives.py
@@ -27,7 +27,7 @@ def models(search_space):
 
 
 @pytest.fixture
-def sample_input() -> Tuple[torch.Tensor]:
+def sample_input() -> torch.Tensor:
     return torch.zeros(1, 1, 192, dtype=torch.long)
 
 

--- a/tests/trainers/cv/test_pl_trainer.py
+++ b/tests/trainers/cv/test_pl_trainer.py
@@ -56,10 +56,12 @@ class Model(pl.LightningModule):
 
 
 def test_pl_trainer():
+    # make sure tests can run in parallel and not clobber each other's dataroot.
+    unique_data_root = 'test_pl_trainer_dataroot'
     model = Model()
     trainer = PlTrainer(max_steps=1, limit_train_batches=1, limit_test_batches=1, limit_predict_batches=1)
 
-    dataset_provider = MnistDatasetProvider()
+    dataset_provider = MnistDatasetProvider(root=unique_data_root)
     train_dataset = dataset_provider.get_train_dataset()
     val_dataset = dataset_provider.get_val_dataset()
 
@@ -68,5 +70,5 @@ def test_pl_trainer():
     trainer.evaluate(model, DataLoader(val_dataset))
     trainer.predict(model, DataLoader(val_dataset))
 
-    shutil.rmtree("dataroot")
+    shutil.rmtree(unique_data_root)
     shutil.rmtree("lightning_logs")


### PR DESCRIPTION
# Pull Request Template

## Description

Minor fixes required to make unit tests work on Windows, the main fix is in the area of handling a weird bug in `tempfile.NamedTemporaryFile` where you cannot open the file again on Windows.  This is fixed with a new file_util class named `TemporaryFiles`.  It also handles some problems with using "rmtree" to cleanup a dataset folder when a memory mapped file is still open in that folder.  Windows does not allow this, so the tests now ensure those memory mapped files are closed before attempting to remove the directory. This PR also adds cross-platform test matrix to our `lint-run-unit-tests.yaml` github workflow so the unit tests are now also run on Windows and they pass.  

Fixes: # 206

## Changes

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to not work as expected)
- [ ] Documentation update


**Configuration**:
* Archai version:
* Environment:
* OS:

## Final checks:

- [ ] Follows guidelines of project
- [ ] Self-review of code
- [ ] Commented code in hard-to-understand areas
- [ ] Corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Dependent changes have already been merged
- [ ] Checked code correction any misspellings