### PR TITLE
fix bug in entity locking.

### DIFF
--- a/archai/common/store.py
+++ b/archai/common/store.py
@@ -228,7 +228,6 @@ class ArchaiStore:
         entity = self.get_existing_status(name)
         if entity is None:
             entity = self.get_status(name)
-            self.update_status_entity(entity)
 
         entity['status'] = status
         if priority:
@@ -277,7 +276,6 @@ class ArchaiStore:
         e = self.get_existing_status(name)
         if e is None:
             e = self.get_status(name)
-            self.update_status_entity(e)
         return self.lock_entity(e, status)
 
     def lock_entity(self, e, status):
@@ -287,8 +285,8 @@ class ArchaiStore:
         running job is allocated to a particular node in a distributed cluster using this
         locking mechanism.  Be sure to call unlock when done, preferably in a try/finally block. """
         node_id = self._get_node_id()
-        if 'node' in e and e['node'] != node_id:
-            name = e['name']
+        name = e['name']
+        if self.is_locked_by_other(name):
             print(f"The model {name} is locked by {e['node']}")
             return None
         e['status'] = status
@@ -319,7 +317,7 @@ class ArchaiStore:
         if e is None:
             return False
         node_id = self._get_node_id()
-        return 'node' in e and e['node'] != node_id
+        return 'node' in e and e['node'] and e['node'] != node_id
 
     def unlock(self, name):
         """ Unlock the entity (regardless of who owns it - so use carefully, preferably only


### PR DESCRIPTION
# Pull Request Template

## Description

Entity locking was confused when the node column was equal to empty string.  This should mean the node is not locked.

Fixes: # (issue)

## Changes

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to not work as expected)
- [ ] Documentation update


**Configuration**:
* Archai version:
* Environment:
* OS:

## Final checks:

- [x] Follows guidelines of project
- [x] Self-review of code
- [x] Commented code in hard-to-understand areas
- [x] Corresponding changes to the documentation
- [x] Changes generate no new warnings
- [x] Dependent changes have already been merged
- [x] Checked code correction any misspellings